### PR TITLE
feat: Fix cellToChildren & cellToParent for low res

### DIFF
--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -143,7 +143,7 @@ describe('serialize', () => {
 });
 
 describe('hierarchy', () => {
-  test.skip('round trip between cellToParent and cellToChildren', () => {
+  test('round trip between cellToParent and cellToChildren', () => {
     TEST_IDS.forEach(id => {
       const cell = BigInt(`0x${id}`);
       const child = cellToChildren(cell)[0];
@@ -154,6 +154,76 @@ describe('hierarchy', () => {
       const parents = children.map(c => cellToParent(c));
       expect(parents.every(p => p === cell)).toBe(true);
     });
+  });
+
+  test('non-Hilbert to non-Hilbert hierarchy', () => {
+    // Test resolution 1 to 2 (both non-Hilbert)
+    const cell = serialize({origin: origin0, segment: 0, S: 0n, resolution: 1});
+    const children = cellToChildren(cell);
+    expect(children.length).toBe(5);
+    children.forEach(child => {
+      const parent = cellToParent(child);
+      expect(parent).toBe(cell);
+    });
+  });
+
+  test('non-Hilbert to Hilbert hierarchy', () => {
+    // Test resolution 2 to 3 (non-Hilbert to Hilbert)
+    const cell = serialize({origin: origin0, segment: 0, S: 0n, resolution: 2});
+    const children = cellToChildren(cell);
+    expect(children.length).toBe(4);
+    children.forEach(child => {
+      const parent = cellToParent(child);
+      expect(parent).toBe(cell);
+    });
+  });
+
+  test('Hilbert to non-Hilbert hierarchy', () => {
+    // Test resolution 3 to 2 (Hilbert to non-Hilbert)
+    const cell = serialize({origin: origin0, segment: 0, S: 0n, resolution: 3});
+    const parent = cellToParent(cell, 2);
+    const children = cellToChildren(parent);
+    expect(children.length).toBe(4);
+    expect(children).toContain(cell);
+  });
+
+  test('low resolution hierarchy chain', () => {
+    // Test a chain of resolutions from 0 to 4
+    const resolutions = [0, 1, 2, 3, 4];
+    const cells = resolutions.map(res => 
+      serialize({origin: origin0, segment: 0, S: 0n, resolution: res})
+    );
+
+    // Test parent relationships
+    for (let i = 1; i < cells.length; i++) {
+      const parent = cellToParent(cells[i]);
+      expect(parent).toBe(cells[i-1]);
+    }
+
+    // Test children relationships
+    for (let i = 0; i < cells.length - 1; i++) {
+      const children = cellToChildren(cells[i]);
+      expect(children).toContain(cells[i+1]);
+    }
+  });
+
+  test('base cell division counts', () => {
+    // Start with the base cell (resolution 0)
+    const baseCell = serialize({origin: origin0, segment: 0, S: 0n, resolution: 0});
+    let currentCells = [baseCell];
+    const expectedCounts = [1, 12, 60, 240, 960]; // 1, 12, 12*5, 12*5*4, 12*5*4*4
+
+    // Test each resolution level up to 4
+    for (let resolution = 0; resolution < 4; resolution++) {
+      // Get all children of current cells
+      const allChildren = currentCells.flatMap(cell => cellToChildren(cell));
+      
+      // Verify the total number of cells matches expected
+      expect(allChildren.length).toBe(expectedCounts[resolution + 1]);
+      
+      // Update current cells for next iteration
+      currentCells = allChildren;
+    }
   });
 });
 


### PR DESCRIPTION
### Changes

- `cellToChildren` correctly splits globe to faces & quintants
- `cellToParent` simplified and correct
- Tests