### PR TITLE
Update area.js

### DIFF
--- a/website/src/examples/area.js
+++ b/website/src/examples/area.js
@@ -16,7 +16,7 @@ class AreaDemo extends Component {
     return (
       <div>
         <p>Area comparison between H3 and A5 tiling systems.</p>
-        <p>H3 cells vary in size across the globe, with the ratio between the largest and smallest cell areas being roughly 2.</p>
+        <p>H3 cells vary in size across the globe, with the ratio between the largest and smallest cell areas being roughly 1.63.</p>
         <p>A5 cells area are more uniform, with the ratio between the largest and smallest cell areas being roughly 1.02.</p>
       </div>
     );


### PR DESCRIPTION
Correct ratio of largest to smallest H3 cells from 2 to 1.63 (729486.88/447684.20) assuming two decimals as precision like for A5 cells. Else, it might be misleading and imply a much bigger difference.
Reference: https://a5geo.org/examples/area