### PR TITLE
Update warp tests

### DIFF
--- a/tests/warp.test.ts
+++ b/tests/warp.test.ts
@@ -21,9 +21,9 @@ describe('normalizeGamma', () => {
   }
 
   it('is periodic with period 2*PI_OVER_5', () => {
-    const TEST_VALUES = [0.01, 0.14, 0.333, 0.5, 0.6198123, 0.77, 0.9];
+    const TEST_VALUES = [-0.977, -0.72, 0.3, 0, 0.01, 0.14, 0.333, 0.5, 0.6198123, 0.77, 0.9];
     for (const value of TEST_VALUES) {
-      const gamma1 = (value * 2 * PI_OVER_5) as Radians;
+      const gamma1 = (value * PI_OVER_5) as Radians;
       const gamma2 = (gamma1 + 2 * PI_OVER_5) as Radians;
       const normalized1 = normalizeGamma(gamma1);
       const normalized2 = normalizeGamma(gamma2);

--- a/tests/warp.test.ts
+++ b/tests/warp.test.ts
@@ -21,11 +21,14 @@ describe('normalizeGamma', () => {
   }
 
   it('is periodic with period 2*PI_OVER_5', () => {
-    const gamma1 = PI_OVER_5 as Radians;
-    const gamma2 = (gamma1 + 2 * PI_OVER_5) as Radians;
-    const normalized1 = normalizeGamma(gamma1);
-    const normalized2 = normalizeGamma(gamma2);
-    expect(normalized1).toBeCloseTo(normalized2);
+    const TEST_VALUES = [0.01, 0.14, 0.333, 0.5, 0.6198123, 0.77, 0.9];
+    for (const value of TEST_VALUES) {
+      const gamma1 = (value * 2 * PI_OVER_5) as Radians;
+      const gamma2 = (gamma1 + 2 * PI_OVER_5) as Radians;
+      const normalized1 = normalizeGamma(gamma1);
+      const normalized2 = normalizeGamma(gamma2);
+      expect(normalized1).toBeCloseTo(normalized2);
+    }
   });
 });
 


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

The old test was checking a point on the boundary between two quintants which made it prone to numerical error. For the periodicity it is better to check a range of points safely within the quintant

<!-- For all the PRs -->
#### Change List
- Test a range of values in the periodicity test case
