### PR TITLE
SphericalPentagonShape & test app

### DIFF
--- a/examples/website/hierarchy/app.tsx
+++ b/examples/website/hierarchy/app.tsx
@@ -34,7 +34,7 @@ const App: React.FC<{showCellId?: boolean}> = ({showCellId = true}) => {
   }, []);
 
   // Calculate resolution based on zoom level
-  let resolution = Math.min(Math.floor(2 * viewState.zoom - 4), Math.floor(viewState.zoom + 3));
+  let resolution = Math.min(Math.floor(2 * viewState.zoom - 4), Math.floor(viewState.zoom + 1));
   resolution = Math.max(1, Math.min(MAX_RESOLUTION, resolution));
 
   // Memoize the entire cells calculation

--- a/examples/website/spherical-polygon/app.tsx
+++ b/examples/website/spherical-polygon/app.tsx
@@ -24,7 +24,7 @@ function Scene({ resolution }: { resolution: number }) {
   // Filter cells based on current point
   const filteredCells = a5cells.filter(cell => {
     const pentagon = sphericalPentagonFromCell(cell);
-    return pentagon.containsPoint(point);
+    return pentagon.containsPoint(point) > 0;
   });
 
   const handleSphereClick = (intersection: Spherical) => {

--- a/examples/website/spherical-polygon/app.tsx
+++ b/examples/website/spherical-polygon/app.tsx
@@ -4,19 +4,20 @@ import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { hexToBigInt, cellToChildren, cellToParent } from 'a5/index';
 import { A5Pentagon, Marker, Sphere, sphericalPentagonFromCell } from './components';
-import { radToDeg, toCartesian } from 'a5/core/coordinate-transforms';
-import { Spherical } from 'a5/core/coordinate-systems';
+import { toCartesian } from 'a5/core/coordinate-transforms';
+import { Cartesian, Spherical } from 'a5/core/coordinate-systems';
 import { vec3 } from 'gl-matrix';
 
-const initialPoint = [2 * Math.PI * Math.random(), Math.PI * Math.random()] as Spherical;
-const camera = toCartesian(initialPoint);
+const initialSpherical = [2 * Math.PI * Math.random(), Math.PI * Math.random()] as Spherical;
+const initialPoint = toCartesian(initialSpherical);
+const camera = toCartesian(initialSpherical);
 vec3.scale(camera, camera, 2);
 
 const a5CellHex = '1200000000000000';
 const a5cell = hexToBigInt(a5CellHex);
 
 function Scene({ resolution }: { resolution: number }) {
-  const [point, setPoint] = useState<Spherical>(initialPoint);
+  const [point, setPoint] = useState<Cartesian>(initialPoint);
 
   // Get cells at current resolution
   const a5cells = cellToChildren(cellToParent(a5cell), resolution);
@@ -28,7 +29,7 @@ function Scene({ resolution }: { resolution: number }) {
   });
 
   const handleSphereClick = (intersection: Spherical) => {
-    setPoint(intersection);
+    setPoint(toCartesian(intersection));
   };
 
   return (
@@ -39,7 +40,7 @@ function Scene({ resolution }: { resolution: number }) {
       <Sphere onSphereClick={handleSphereClick} />
       {filteredCells.map(cell => <A5Pentagon key={cell.toString()} cell={cell} disabled={false} />)}
       {a5cells.map(cell => <A5Pentagon key={cell.toString()} cell={cell} disabled={true} />)}
-      <Marker spherical={point} />
+      <Marker cartesian={point} />
       <OrbitControls enableDamping enableZoom={true} minPolarAngle={0} maxPolarAngle={Math.PI} minDistance={1.02} maxDistance={10} enablePan={false} />
     </>
   );

--- a/examples/website/spherical-polygon/app.tsx
+++ b/examples/website/spherical-polygon/app.tsx
@@ -1,0 +1,107 @@
+import React, { Suspense, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { hexToBigInt, cellToChildren, cellToParent } from 'a5/index';
+import { A5Pentagon, Marker, Sphere, sphericalPentagonFromCell } from './components';
+import { radToDeg, toCartesian } from 'a5/core/coordinate-transforms';
+import { Spherical } from 'a5/core/coordinate-systems';
+import { vec3 } from 'gl-matrix';
+
+const initialPoint = [2 * Math.PI * Math.random(), Math.PI * Math.random()] as Spherical;
+const camera = toCartesian(initialPoint);
+vec3.scale(camera, camera, 2);
+
+const a5CellHex = '1200000000000000';
+const a5cell = hexToBigInt(a5CellHex);
+
+function Scene({ resolution }: { resolution: number }) {
+  const [point, setPoint] = useState<Spherical>(initialPoint);
+
+  // Get cells at current resolution
+  const a5cells = cellToChildren(cellToParent(a5cell), resolution);
+
+  // Filter cells based on current point
+  const filteredCells = a5cells.filter(cell => {
+    const pentagon = sphericalPentagonFromCell(cell);
+    return pentagon.containsPoint(point);
+  });
+
+  const handleSphereClick = (intersection: Spherical) => {
+    setPoint(intersection);
+  };
+
+  return (
+    <>
+      <ambientLight intensity={0.3} />
+      <directionalLight position={[10, 10, 10]} intensity={1.5} />
+      <directionalLight position={[-10, -8, -10]} intensity={0.4} />
+      <Sphere onSphereClick={handleSphereClick} />
+      {filteredCells.map(cell => <A5Pentagon key={cell.toString()} cell={cell} disabled={false} />)}
+      {a5cells.map(cell => <A5Pentagon key={cell.toString()} cell={cell} disabled={true} />)}
+      <Marker spherical={point} />
+      <OrbitControls enableDamping enableZoom={true} minPolarAngle={0} maxPolarAngle={Math.PI} minDistance={1.02} maxDistance={10} enablePan={false} />
+    </>
+  );
+}
+
+const App: React.FC = () => {
+  const [resolution, setResolution] = useState(3);
+
+  return (
+    <div style={{
+      position: 'absolute',
+      height: '100%',
+      width: '100%',
+      top: 0,
+      left: 0,
+      background: 'linear-gradient(0, #000, #223)'
+    }}>
+      <div style={{
+        position: 'absolute',
+        bottom: '20px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'white',
+        padding: '10px',
+        borderRadius: '4px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+        zIndex: 1,
+        width: '300px',
+        textAlign: 'center'
+      }}>
+        <div style={{ marginBottom: '5px' }}>
+          Resolution: {resolution}
+        </div>
+        <input
+          type="range"
+          min="1"
+          max="5"
+          value={resolution}
+          onChange={(e) => setResolution(Number(e.target.value))}
+          style={{ 
+            width: '100%',
+            height: '20px',
+            WebkitAppearance: 'none',
+            background: 'rgba(135, 206, 235, 0.2)',
+            borderRadius: '10px',
+            outline: 'none'
+          }}
+        />
+      </div>
+
+      <Canvas camera={{ position: camera, near: 0.001, far: 1000 }}>
+        <Suspense fallback={null}>
+          <Scene resolution={resolution} />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+};
+
+export default App;
+
+export async function renderToDOM(container: HTMLDivElement) {
+  const root = createRoot(container);
+  root.render(<App />);
+} 

--- a/examples/website/spherical-polygon/components.tsx
+++ b/examples/website/spherical-polygon/components.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react';
+import { BufferGeometry, Float32BufferAttribute, DoubleSide, Vector3, Raycaster, Sphere as ThreeSphere } from 'three';
+import { SphericalPentagon, SphericalPentagonShape } from 'a5/core/spherical-pentagon';
+import { toCartesian, fromLonLat, toSpherical } from 'a5/core/coordinate-transforms';
+import { cellToBoundary } from 'a5/index';
+import type { Spherical, Radians, Cartesian } from 'a5/core/coordinate-systems';
+import { useThree } from '@react-three/fiber';
+
+export function Sphere({ onSphereClick }: { onSphereClick: (point: Spherical) => void }) {
+  const { camera} = useThree();
+
+  const handleClick = (event: { clientX: number; clientY: number }) => {
+    const spherical = toSpherical(camera.position.toArray() as Cartesian);
+    onSphereClick(spherical);
+  };
+
+  return (
+    <mesh onClick={handleClick}>
+      <sphereGeometry args={[0.999, 64, 64]} />
+      <meshPhysicalMaterial 
+        color="#00aa55"
+        opacity={0.05}
+        metalness={0.5}
+        roughness={0.7}
+        emissive="#00aa55"
+        emissiveIntensity={0.1}
+      />
+    </mesh>
+  );
+}
+
+export function PentagonLines(props: { sphericalPentagon: SphericalPentagonShape, disabled: boolean }) {
+  const { sphericalPentagon, disabled } = props;
+  const geometry = useMemo(() => {
+    // Use 20 segments per edge for smooth curves
+    const vertices = sphericalPentagon.getBoundary(20);
+    const points = vertices.flatMap(vertex => {
+      const cartesian = toCartesian(vertex);
+      return [cartesian[0], cartesian[1], cartesian[2]];
+    });
+    
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute(points, 3));
+    return geometry;
+  }, [sphericalPentagon]);
+
+  return (
+    <line geometry={geometry}>
+      <lineBasicMaterial color="#ffffff" opacity={0.1} transparent={disabled} linewidth={2} />
+    </line>
+  );
+}
+
+export function sphericalPentagonFromCell(cell: bigint): SphericalPentagonShape {
+  const boundary = cellToBoundary(cell);
+  const sphericalBoundary = boundary.map(lonlat => fromLonLat(lonlat));
+  return new SphericalPentagonShape(sphericalBoundary);
+}
+
+export function A5Pentagon(props: { cell: bigint, disabled: boolean }) {
+  const {cell, disabled} = props;
+  const a5Pentagon = sphericalPentagonFromCell(cell);
+  return <PentagonLines sphericalPentagon={a5Pentagon} disabled={disabled} />;
+}
+
+export function Marker(props: { spherical: Spherical }) {
+  const cartesian = toCartesian(props.spherical);
+  return (
+    <mesh position={cartesian}>
+      <sphereGeometry args={[0.003, 16, 16]} />
+      <meshPhysicalMaterial
+        color="#ff0000"
+        metalness={0.2}
+        roughness={0}
+      />
+    </mesh>
+  );
+} 

--- a/examples/website/spherical-polygon/components.tsx
+++ b/examples/website/spherical-polygon/components.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { BufferGeometry, Float32BufferAttribute, DoubleSide, Vector3, Raycaster, Sphere as ThreeSphere } from 'three';
-import { SphericalPentagon, SphericalPentagonShape } from 'a5/core/spherical-pentagon';
+import { SphericalPentagonShape } from 'a5/core/spherical-pentagon';
 import { toCartesian, fromLonLat, toSpherical } from 'a5/core/coordinate-transforms';
 import { cellToBoundary } from 'a5/index';
 import type { Spherical, Radians, Cartesian } from 'a5/core/coordinate-systems';
@@ -34,13 +34,8 @@ export function PentagonLines(props: { sphericalPentagon: SphericalPentagonShape
   const geometry = useMemo(() => {
     // Use 20 segments per edge for smooth curves
     const vertices = sphericalPentagon.getBoundary(20);
-    const points = vertices.flatMap(vertex => {
-      const cartesian = toCartesian(vertex);
-      return [cartesian[0], cartesian[1], cartesian[2]];
-    });
-    
     const geometry = new BufferGeometry();
-    geometry.setAttribute('position', new Float32BufferAttribute(points, 3));
+    geometry.setAttribute('position', new Float32BufferAttribute(vertices.flatMap(p => [...p]), 3));
     return geometry;
   }, [sphericalPentagon]);
 
@@ -53,8 +48,8 @@ export function PentagonLines(props: { sphericalPentagon: SphericalPentagonShape
 
 export function sphericalPentagonFromCell(cell: bigint): SphericalPentagonShape {
   const boundary = cellToBoundary(cell);
-  const sphericalBoundary = boundary.map(lonlat => fromLonLat(lonlat));
-  return new SphericalPentagonShape(sphericalBoundary);
+  const cartesianBoundary = boundary.map(lonlat => toCartesian(fromLonLat(lonlat)));
+  return new SphericalPentagonShape(cartesianBoundary);
 }
 
 export function A5Pentagon(props: { cell: bigint, disabled: boolean }) {
@@ -63,8 +58,8 @@ export function A5Pentagon(props: { cell: bigint, disabled: boolean }) {
   return <PentagonLines sphericalPentagon={a5Pentagon} disabled={disabled} />;
 }
 
-export function Marker(props: { spherical: Spherical }) {
-  const cartesian = toCartesian(props.spherical);
+export function Marker(props: { cartesian: Cartesian }) {
+  const cartesian = props.cartesian;
   return (
     <mesh position={cartesian}>
       <sphereGeometry args={[0.003, 16, 16]} />

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -5,7 +5,7 @@
 import { mat2, vec2, glMatrix } from "gl-matrix";
 glMatrix.setMatrixArrayType(Float64Array as any);
 
-import type { Face, LonLat } from "./coordinate-systems";
+import type { Face, LonLat, Spherical } from "./coordinate-systems";
 import { FaceToIJ, fromLonLat, toFace } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { unprojectDodecahedron } from "./dodecahedron";
@@ -15,6 +15,7 @@ import { PI_OVER_5 } from "./constants";
 import { IJToS, sToAnchor } from "./hilbert";
 import { projectPentagon, projectPoint, reprojectPentagon } from "./project";
 import { deserialize, serialize, FIRST_HILBERT_RESOLUTION } from "./serialization";
+import { SphericalPentagonShape } from "./spherical-pentagon";
 
 // Reuse these objects to avoid allocation
 const rotation = mat2.create();
@@ -56,7 +57,7 @@ export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
 
   for (const estimate of uniqueEstimates) {
     const distance = a5cellContainsPoint(estimate, lonLat);
-    if (distance < 0) {
+    if (distance > 0) {
       return serialize(estimate);
     } else {
       cells.push({cell: estimate, distance});
@@ -64,7 +65,7 @@ export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
   }
 
   // Sort cells by distance and use the closest one
-  cells.sort((a, b) => a.distance - b.distance);
+  cells.sort((a, b) => b.distance - a.distance);
   return serialize(cells[0].cell);
 }
 
@@ -129,7 +130,12 @@ export function cellToBoundary(cellId: bigint): LonLat[] {
 }
 
 export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
-  const spherical = fromLonLat(point);
+  const spherical = point as unknown as Spherical;
+
+  const boundary = cellToBoundary(serialize(cell));
+  const sphericalBoundary = boundary as unknown as Spherical[];
+  const sphericalPentagon = new SphericalPentagonShape(sphericalBoundary);
+  return sphericalPentagon.containsPoint(spherical);
 
   // Important to use the same origin as the cell, so we unproject onto correct face
   const {origin} = cell;

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -6,7 +6,7 @@ import { mat2, vec2, glMatrix } from "gl-matrix";
 glMatrix.setMatrixArrayType(Float64Array as any);
 
 import type { Cartesian, Degrees, Face, LonLat, Spherical } from "./coordinate-systems";
-import { degToRad, FaceToIJ, fromLonLat, lonLatToCartesian, toCartesian, toFace } from "./coordinate-transforms";
+import { FaceToIJ, fromLonLat, toCartesian, toFace } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { unprojectDodecahedron } from "./dodecahedron";
 import { A5Cell, Pentagon, PentagonShape } from "./utils";
@@ -132,8 +132,8 @@ export function cellToBoundary(cellId: bigint): LonLat[] {
 export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
   const boundary = cellToBoundary(serialize(cell));
 
-  const cartesian = lonLatToCartesian(point);
-  const sphericalBoundary = boundary.map(lonLatToCartesian);
+  const cartesian = toCartesian(fromLonLat(point));
+  const sphericalBoundary = boundary.map(vertex => toCartesian(fromLonLat(vertex)));
 
   const sphericalPentagon = new SphericalPentagonShape(sphericalBoundary);
   return sphericalPentagon.containsPoint(cartesian);

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -5,8 +5,8 @@
 import { mat2, vec2, glMatrix } from "gl-matrix";
 glMatrix.setMatrixArrayType(Float64Array as any);
 
-import type { Face, LonLat, Spherical } from "./coordinate-systems";
-import { FaceToIJ, fromLonLat, toFace } from "./coordinate-transforms";
+import type { Cartesian, Degrees, Face, LonLat, Spherical } from "./coordinate-systems";
+import { degToRad, FaceToIJ, fromLonLat, toCartesian, toFace } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { unprojectDodecahedron } from "./dodecahedron";
 import { A5Cell, Pentagon, PentagonShape } from "./utils";
@@ -129,13 +129,18 @@ export function cellToBoundary(cellId: bigint): LonLat[] {
   return projectPentagon(pentagon, origin);
 }
 
-export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
-  const spherical = point as unknown as Spherical;
+function lonLatToCartesian(lonLat: LonLat): Cartesian {
+  return toCartesian(fromLonLat(lonLat));
+}
 
+export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
   const boundary = cellToBoundary(serialize(cell));
-  const sphericalBoundary = boundary as unknown as Spherical[];
+
+  const cartesian = lonLatToCartesian(point);
+  const sphericalBoundary = boundary.map(lonLatToCartesian);
+
   const sphericalPentagon = new SphericalPentagonShape(sphericalBoundary);
-  return sphericalPentagon.containsPoint(spherical);
+  return sphericalPentagon.containsPoint(cartesian);
 
   // Important to use the same origin as the cell, so we unproject onto correct face
   const {origin} = cell;

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -27,7 +27,7 @@ export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
 
   const hilbertResolution = 1 + resolution - FIRST_HILBERT_RESOLUTION;
   const samples: LonLat[] = [lonLat];
-  const N = 100;
+  const N = 25;
   const scale = 50 / Math.pow(2, hilbertResolution);
   for (let i = 0; i < N; i++) {
     const R = (i / N) * scale;

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -5,15 +5,15 @@
 import { mat2, vec2, glMatrix } from "gl-matrix";
 glMatrix.setMatrixArrayType(Float64Array as any);
 
-import type { Cartesian, Degrees, Face, LonLat, Spherical } from "./coordinate-systems";
+import type { Face, LonLat } from "./coordinate-systems";
 import { FaceToIJ, fromLonLat, toCartesian, toFace } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { unprojectDodecahedron } from "./dodecahedron";
-import { A5Cell, Pentagon, PentagonShape } from "./utils";
-import { getFaceVertices, getPentagonVertices, getQuintant, getQuintantPolar, getQuintantVertices } from "./tiling";
+import { A5Cell, PentagonShape } from "./utils";
+import { getFaceVertices, getPentagonVertices, getQuintantPolar, getQuintantVertices } from "./tiling";
 import { PI_OVER_5 } from "./constants";
 import { IJToS, sToAnchor } from "./hilbert";
-import { projectPentagon, projectPoint, reprojectPentagon } from "./project";
+import { projectPentagon, projectPoint } from "./project";
 import { deserialize, serialize, FIRST_HILBERT_RESOLUTION } from "./serialization";
 import { SphericalPentagonShape } from "./spherical-pentagon";
 

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -37,34 +37,30 @@ export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
     samples.push(coordinate as LonLat);
   }
 
-  const cells: {cell: A5Cell, distance: number}[] = [];
-  const estimates: {estimate: A5Cell, sample: LonLat}[] = [];
-  for (const sample of samples) {
-    const estimate = _lonLatToEstimate(sample, resolution);
-    estimates.push({estimate, sample});
-  }
-
   // Deduplicate estimates
   const estimateSet = new Set<bigint>();
   const uniqueEstimates: A5Cell[] = [];
-  for (const {estimate, sample} of estimates) {
+
+  const cells: {cell: A5Cell, distance: number}[] = [];
+  for (const sample of samples) {
+    const estimate = _lonLatToEstimate(sample, resolution);
     const estimateKey = serialize(estimate);
     if (!estimateSet.has(estimateKey)) {
+      // Have new estimate, add to set and list
       estimateSet.add(estimateKey);
       uniqueEstimates.push(estimate);
+
+      // Check if we have a hit, storing distance if not
+      const distance = a5cellContainsPoint(estimate, lonLat);
+      if (distance > 0) {
+        return serialize(estimate);
+      } else {
+        cells.push({cell: estimate, distance});
+      }
     }
   }
 
-  for (const estimate of uniqueEstimates) {
-    const distance = a5cellContainsPoint(estimate, lonLat);
-    if (distance > 0) {
-      return serialize(estimate);
-    } else {
-      cells.push({cell: estimate, distance});
-    }
-  }
-
-  // Sort cells by distance and use the closest one
+  // As fallback, sort cells by distance and use the closest one
   cells.sort((a, b) => b.distance - a.distance);
   return serialize(cells[0].cell);
 }

--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -6,7 +6,7 @@ import { mat2, vec2, glMatrix } from "gl-matrix";
 glMatrix.setMatrixArrayType(Float64Array as any);
 
 import type { Cartesian, Degrees, Face, LonLat, Spherical } from "./coordinate-systems";
-import { degToRad, FaceToIJ, fromLonLat, toCartesian, toFace } from "./coordinate-transforms";
+import { degToRad, FaceToIJ, fromLonLat, lonLatToCartesian, toCartesian, toFace } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { unprojectDodecahedron } from "./dodecahedron";
 import { A5Cell, Pentagon, PentagonShape } from "./utils";
@@ -129,10 +129,6 @@ export function cellToBoundary(cellId: bigint): LonLat[] {
   return projectPentagon(pentagon, origin);
 }
 
-function lonLatToCartesian(lonLat: LonLat): Cartesian {
-  return toCartesian(fromLonLat(lonLat));
-}
-
 export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
   const boundary = cellToBoundary(serialize(cell));
 
@@ -141,16 +137,4 @@ export function a5cellContainsPoint(cell: A5Cell, point: LonLat): number {
 
   const sphericalPentagon = new SphericalPentagonShape(sphericalBoundary);
   return sphericalPentagon.containsPoint(cartesian);
-
-  // Important to use the same origin as the cell, so we unproject onto correct face
-  const {origin} = cell;
-  const polar = unprojectDodecahedron(spherical, origin.quat, origin.angle);
-  const face = toFace(polar);
-
-  // Required for points on pentagon that cross the origin boundary
-  const pentagon = _getPentagon(cell);
-  const reprojectedPentagon = reprojectPentagon(pentagon, origin);
-
-  // Perform containment test in Face coordinates, where cell edges are straight lines
-  return reprojectedPentagon.containsPoint(face);
 }

--- a/modules/core/coordinate-transforms.ts
+++ b/modules/core/coordinate-transforms.ts
@@ -84,6 +84,16 @@ export function toLonLat([theta, phi]: Spherical): LonLat {
 }
 
 /**
+ * Convert longitude/latitude directly to Cartesian coordinates
+ * @param lon Longitude in degrees (0 to 360)
+ * @param lat Latitude in degrees (-90 to 90)
+ * @returns [x, y, z] (unit vector)
+ */
+export function lonLatToCartesian(lonLat: LonLat): Cartesian {
+  return toCartesian(fromLonLat(lonLat));
+}
+
+/**
  * Creates a quaternion representing a rotation
  * from the north pole to a given axis.
  * @param axis Spherical coordinate of axis to rotate to

--- a/modules/core/coordinate-transforms.ts
+++ b/modules/core/coordinate-transforms.ts
@@ -42,12 +42,12 @@ export function toSpherical(xyz: Cartesian): Spherical {
 }
 
 export function toCartesian([theta, phi]: Spherical): Cartesian {
-  const x = Math.sin(phi) * Math.cos(theta);
-  const y = Math.sin(phi) * Math.sin(theta);
+  const sinPhi = Math.sin(phi);
+  const x = sinPhi * Math.cos(theta);
+  const y = sinPhi * Math.sin(theta);
   const z = Math.cos(phi);
   return [x, y, z] as Cartesian;
 }
-
 
 /**
  * Determine the offset longitude for the spherical coordinate system
@@ -81,16 +81,6 @@ export function toLonLat([theta, phi]: Spherical): LonLat {
   const longitude = radToDeg(theta) - LONGITUDE_OFFSET as Degrees;
   const latitude = (90 - radToDeg(phi)) as Degrees;
   return [longitude, latitude] as LonLat;
-}
-
-/**
- * Convert longitude/latitude directly to Cartesian coordinates
- * @param lon Longitude in degrees (0 to 360)
- * @param lat Latitude in degrees (-90 to 90)
- * @returns [x, y, z] (unit vector)
- */
-export function lonLatToCartesian(lonLat: LonLat): Cartesian {
-  return toCartesian(fromLonLat(lonLat));
 }
 
 /**

--- a/modules/core/coordinate-transforms.ts
+++ b/modules/core/coordinate-transforms.ts
@@ -83,6 +83,12 @@ export function toLonLat([theta, phi]: Spherical): LonLat {
   return [longitude, latitude] as LonLat;
 }
 
+/**
+ * Creates a quaternion representing a rotation
+ * from the north pole to a given axis.
+ * @param axis Spherical coordinate of axis to rotate to
+ * @returns quaternion
+ */
 export function quatFromSpherical(axis: Spherical): quat {
   const cartesian = toCartesian(axis);
   const Q = quat.create();

--- a/modules/core/project.ts
+++ b/modules/core/project.ts
@@ -4,13 +4,13 @@
 
 import { vec2, mat2, glMatrix } from 'gl-matrix';
 glMatrix.setMatrixArrayType(Float64Array as any);
-import { Pentagon, PentagonShape } from './utils';
+import { PentagonShape } from './utils';
 import { Origin } from './utils';
 import { movePointToFace, findNearestOrigin, isNearestOrigin } from './origin';
-import { projectDodecahedron, unprojectDodecahedron } from './dodecahedron';
-import type { Face, LonLat, Polar, Radians } from './coordinate-systems';
-import { fromLonLat, toFace, toLonLat, toPolar } from './coordinate-transforms';
-import { distanceToEdge, PI_OVER_5 } from './constants';
+import { projectDodecahedron } from './dodecahedron';
+import type { Face, LonLat, Radians } from './coordinate-systems';
+import { toLonLat, toPolar } from './coordinate-transforms';
+import { PI_OVER_5 } from './constants';
 
 // Reusable matrices to avoid recreation
 const rotation = mat2.create();

--- a/modules/core/project.ts
+++ b/modules/core/project.ts
@@ -52,37 +52,3 @@ export function projectPentagon(pentagon: PentagonShape, origin: Origin): LonLat
   const normalizedVertices = PentagonShape.normalizeLongitudes(rotatedVertices);
   return normalizedVertices;
 }
-
-/**
- * Reproject a pentagon so that all vertices are defined in the same Face coordinate system
- * of a single origin. This is required for containment testing as the vertices of a cell
- * can span multiple origins, which are warped differently. Applying this function allows
- * us to perform containment testing in Face coordinates, where cell edges are straight lines.
- * @param pentagon 
- * @param origin 
- * @returns 
- */
-export function reprojectPentagon(pentagon: PentagonShape, origin: Origin): PentagonShape {
-  // If all vertices are within a single origin, we can just return the pentagon
-  let withinSingleOrigin = true;
-  for (const vertex of pentagon.getVertices()) {
-    const D = vec2.length(vertex);
-    if (D > distanceToEdge) {
-      withinSingleOrigin = false;
-      break;
-    }
-  }
-
-  if (withinSingleOrigin) {
-    return pentagon;
-  }
-
-  // Project to sphere, projectPoint will handle "folding" vertices across the dodecahedron edges
-  const projectedPentagon = projectPentagon(pentagon, origin);
-  const sphericalPentagon = projectedPentagon.map(fromLonLat);
-
-  // Unproject to dodecahedron, with all vertices now defined in the same Face coordinate system
-  const polarPentagon = sphericalPentagon.map(spherical => unprojectDodecahedron(spherical, origin.quat, origin.angle));
-  const facePentagon = polarPentagon.map(polar => toFace(polar)) as Pentagon;
-  return new PentagonShape(facePentagon);
-}

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -1,0 +1,146 @@
+// A5
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) A5 contributors
+
+import {vec2, mat2, mat2d, vec3, glMatrix, quat} from 'gl-matrix';
+glMatrix.setMatrixArrayType(Float64Array as any);
+import type { Radians, Spherical, Face, Degrees, LonLat, Cartesian } from './coordinate-systems';
+import { quatFromSpherical, radToDeg, toCartesian, toSpherical } from './coordinate-transforms';
+
+export type SphericalPolygon = Spherical[];
+const UP = [0, 0, 1] as Cartesian;
+
+export class SphericalPentagonShape {
+  private vertices: SphericalPolygon;
+
+  constructor(vertices: SphericalPolygon) {
+    this.vertices = vertices;
+    if (!this.isWindingCorrect()) {
+      this.vertices.reverse();
+    }
+  }
+
+  private isWindingCorrect(): boolean {
+    return this.getArea() >= 0;
+  }
+
+  getArea(): number {
+    let signedArea = 0;
+    const N = this.vertices.length;
+    for (let i = 0; i < N; i++) {
+      const j = (i + 1) % N;
+      signedArea += (this.vertices[j][0] - this.vertices[i][0]) * (this.vertices[j][1] + this.vertices[i][1]);
+    }
+    return signedArea;
+  }
+
+  getBoundary(nSegments: number = 1): Spherical[] {
+    const points: Spherical[] = [];
+    const N = this.vertices.length;
+    for (let s = 0; s < N * nSegments; s++) {
+      const t = s / nSegments;
+      points.push(this.slerp(t));
+    }
+    points.push(points[0]);
+    
+    return points;
+  }
+
+  /**
+   * Interpolates along boundary of polygon. Pass t = 1.5 to get the midpoint between 2nd and 3rd vertices
+   * @param t 
+   * @returns Spherical (lat, lon) coordinate
+   */
+  slerp(t: number): Spherical {
+    const N = this.vertices.length;
+    const f = t % 1;
+    const i = Math.floor(t % N);
+    const j = (i + 1) % N;
+
+    // Points A & B
+    const A = toCartesian(this.vertices[i]);
+    const B = toCartesian(this.vertices[j]);
+
+    // Quaternions
+    const identity = quat.create();
+    const qOA = quat.rotationTo(quat.create(), UP, A);
+    const qAB = quat.rotationTo(quat.create(), A, B);
+    const qPartial = quat.slerp(quat.create(), identity, qAB, f);
+    const qCombined = quat.multiply(quat.create(), qPartial, qOA);
+
+    const out = vec3.fromValues(0, 0, 1);
+    vec3.transformQuat(out, out, qCombined);
+    return toSpherical(out as Cartesian);
+  }
+
+  getVertexQuat(t: number): quat {
+    const N = this.vertices.length;
+    const i = Math.floor(t % N);
+    const j = (i + 1) % N;
+
+    // Points A & B
+    const A = toCartesian(this.vertices[i]);
+    const B = toCartesian(this.vertices[j]);
+
+    // Rotation from vertex A to origin (north pole)
+    const qAO = quat.rotationTo(quat.create(), A, UP);
+
+    // Rotate B into coordinate system of A
+    const _A = vec3.transformQuat(vec3.create(), A, qAO);
+    const _B = vec3.transformQuat(vec3.create(), B, qAO);
+    const _theta = Math.atan2(_B[1], _B[0]) as Radians;
+
+
+    const qTwist = quat.setAxisAngle(quat.create(), UP, -_theta);
+    vec3.transformQuat(_A, _A, qTwist);
+    vec3.transformQuat(_B, _B, qTwist);
+
+    // Rotate such that B lies it is along x-axis
+    quat.multiply(qAO, qTwist, qAO);
+    return qAO;
+  }
+
+  getVertexAngles(t: number): [Radians, Radians] {
+    const N = this.vertices.length;
+    const i = Math.floor(t % N);
+    const j = (i + 1) % N;
+    const k = (i + N - 1) % N;
+
+    // Points A & B (vertex before and after)
+    const V = toCartesian(this.vertices[i]);
+    const A = toCartesian(this.vertices[j]);
+    const B = toCartesian(this.vertices[k]);
+
+    // Quat to rotate into coordinate system of vertex
+    const qV = this.getVertexQuat(t);
+
+    vec3.transformQuat(V, V, qV);
+    vec3.transformQuat(A, A, qV);
+    vec3.transformQuat(B, B, qV);
+
+    const thetaA = Math.atan2(A[1], A[0]) as Radians;
+    const thetaB = Math.atan2(B[1], B[0]) as Radians;
+    if (Math.abs(thetaA) > 1e-12) {
+      throw new Error(`thetaA is not near 0: ${thetaA}`);
+    }
+    return [thetaA, thetaB];
+  }
+
+  containsPoint(point: Spherical): boolean {
+    const N = this.vertices.length;
+    for (let i = 0; i < N; i++) {
+      // Transform point into coordinate system of vertex
+      const X = toCartesian(point);
+      const qV = this.getVertexQuat(i);
+      vec3.transformQuat(X, X, qV);
+
+      // Check if point is within vertex angles
+      const vertexAngles = this.getVertexAngles(i);
+      const thetaX = Math.atan2(X[1], X[0]) as Radians;
+      if (thetaX < vertexAngles[0] || thetaX > vertexAngles[1]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -94,6 +94,8 @@ export class SphericalPentagonShape {
 
     // Rotation from vertex A to origin (north pole)
     const qAO = quat.rotationTo(quat.create(), A, UP);
+    const axis = vec3.create();
+    const angle = quat.getAxisAngle(axis, qAO);
 
     // Rotate B into coordinate system of A
     // const _A = vec3.transformQuat(vec3.create(), A, qAO);
@@ -109,16 +111,19 @@ export class SphericalPentagonShape {
     return qAO;
   }
 
-  transformVertices(t: number): [Cartesian, Cartesian] {
+  transformVertices(t: number): [Cartesian, Cartesian, Cartesian] {
     const N = this.vertices.length;
     const i = Math.floor(t % N);
     const j = (i + 1) % N;
     const k = (i + N - 1) % N;
 
     // Points A & B (vertex before and after)
-    const V = this.vertices[i];
-    const A = this.vertices[j];
-    const B = this.vertices[k];
+    const V = vec3.clone(this.vertices[i]) as Cartesian;
+    const A = vec3.clone(this.vertices[j]) as Cartesian;
+    const B = vec3.clone(this.vertices[k]) as Cartesian;
+    vec3.sub(A, A, V);
+    vec3.sub(B, B, V);
+    return [V, A, B];
 
     // Quat to rotate into coordinate system of vertex
     const qV = this.getVertexQuat(t);
@@ -135,25 +140,26 @@ export class SphericalPentagonShape {
 
   containsPoint(point: Cartesian): number {
     const N = this.vertices.length;
-    console.log(this.vertices)
     let thetaDeltaMin = Infinity;
     for (let i = 0; i < N; i++) {
       // Transform point into coordinate system of vertex
-      const qV = this.getVertexQuat(i);
-      const X = vec3.transformQuat(vec3.create(), point, qV);
+      //const qV = this.getVertexQuat(i);
+      // const X = vec3.transformQuat(vec3.create(), point, qV);
+      const X = vec3.clone(point) as Cartesian;
 
-      // Check if point is within vertex angles
-      const [A, B] = this.transformVertices(i);
-      A[2] = 0;
-      B[2] = 0;
-      X[2] = 0;
+      // Move origin to V
+      const [V, A, B] = this.transformVertices(i);
+      vec3.sub(X, X, V);
 
       vec3.normalize(A, A);
       vec3.normalize(B, B);
       vec3.normalize(X, X);
 
-      const sinXA = vec3.cross(vec3.create(), X, A)[2];
-      const sinBX = vec3.cross(vec3.create(), B, X)[2];
+      const crossXA = vec3.cross(vec3.create(), X, A);
+      const crossBX = vec3.cross(vec3.create(), B, X);
+
+      const sinXA = vec3.dot(V, crossXA);
+      const sinBX = vec3.dot(V, crossBX);
 
       thetaDeltaMin = Math.min(thetaDeltaMin, sinXA, sinBX);
     }

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -111,7 +111,14 @@ export class SphericalPentagonShape {
     return qAO;
   }
 
-  transformVertices(t: number): [Cartesian, Cartesian, Cartesian] {
+  /**
+   * Returns the vertex given by index t, along with the vectors:
+   * - VA: Vector from vertex to point A
+   * - VB: Vector from vertex to point B
+   * @param t 
+   * @returns 
+   */
+  getTransformedVertices(t: number): [Cartesian, Cartesian, Cartesian] {
     const N = this.vertices.length;
     const i = Math.floor(t % N);
     const j = (i + 1) % N;
@@ -119,50 +126,45 @@ export class SphericalPentagonShape {
 
     // Points A & B (vertex before and after)
     const V = vec3.clone(this.vertices[i]) as Cartesian;
-    const A = vec3.clone(this.vertices[j]) as Cartesian;
-    const B = vec3.clone(this.vertices[k]) as Cartesian;
-    vec3.sub(A, A, V);
-    vec3.sub(B, B, V);
-    return [V, A, B];
-
-    // Quat to rotate into coordinate system of vertex
-    const qV = this.getVertexQuat(t);
-
-    const _V = vec3.transformQuat(vec3.create(), V, qV);
-    const _A = vec3.transformQuat(vec3.create(), A, qV) as Cartesian;
-    const _B = vec3.transformQuat(vec3.create(), B, qV) as Cartesian;
-    return [_A, _B];
-
-    // const thetaA = Math.atan2(_A[1], _A[0]) as Radians;
-    // const thetaB = Math.atan2(_B[1], _B[0]) as Radians;
-    // return [thetaA, thetaB];
+    const VA = vec3.clone(this.vertices[j]) as Cartesian;
+    const VB = vec3.clone(this.vertices[k]) as Cartesian;
+    vec3.sub(VA, VA, V);
+    vec3.sub(VB, VB, V);
+    return [V, VA, VB];
   }
 
   containsPoint(point: Cartesian): number {
     const N = this.vertices.length;
     let thetaDeltaMin = Infinity;
+
     for (let i = 0; i < N; i++) {
-      // Transform point into coordinate system of vertex
-      //const qV = this.getVertexQuat(i);
-      // const X = vec3.transformQuat(vec3.create(), point, qV);
-      const X = vec3.clone(point) as Cartesian;
+      // Transform point and neighboring vertices into coordinate system of vertex
+      const [V, VA, VB] = this.getTransformedVertices(i);
+      const VP = vec3.sub(vec3.create(), point, V);
 
-      // Move origin to V
-      const [V, A, B] = this.transformVertices(i);
-      vec3.sub(X, X, V);
+      // Normalize direction vectors
+      vec3.normalize(VP, VP);
+      vec3.normalize(VA, VA);
+      vec3.normalize(VB, VB);
 
-      vec3.normalize(A, A);
-      vec3.normalize(B, B);
-      vec3.normalize(X, X);
+      // Cross products will point away from the center of the sphere when
+      // point P is within arc formed by VA and VB
+      const crossPA = vec3.cross(vec3.create(), VP, VA);
+      const crossBP = vec3.cross(vec3.create(), VB, VP);
 
-      const crossXA = vec3.cross(vec3.create(), X, A);
-      const crossBX = vec3.cross(vec3.create(), B, X);
+      // Dot product will be positive when point P is within arc formed by VA and VB
+      // The magnitude of the dot product is the sine of the angle between the two vectors
+      // which is the same as the angle for small angles.
+      const sinPA = vec3.dot(V, crossPA);
+      const sinBP = vec3.dot(V, crossBP);
 
-      const sinXA = vec3.dot(V, crossXA);
-      const sinBX = vec3.dot(V, crossBX);
-
-      thetaDeltaMin = Math.min(thetaDeltaMin, sinXA, sinBX);
+      // By returning the minimum value we find the arc where the point is closest to being outside
+      thetaDeltaMin = Math.min(thetaDeltaMin, sinPA, sinBP);
     }
+
+    // If point is inside all arcs, will return a position value
+    // If point is on edge of arc, will return 0
+    // If point is outside all arcs, will return -1, the further away from 0, the further away from the arc
     return thetaDeltaMin;
   }
 }

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -96,20 +96,20 @@ export class SphericalPentagonShape {
     const qAO = quat.rotationTo(quat.create(), A, UP);
 
     // Rotate B into coordinate system of A
-    const _A = vec3.transformQuat(vec3.create(), A, qAO);
-    const _B = vec3.transformQuat(vec3.create(), B, qAO);
-    const _theta = Math.atan2(_B[1], _B[0]) as Radians;
+    // const _A = vec3.transformQuat(vec3.create(), A, qAO);
+    // const _B = vec3.transformQuat(vec3.create(), B, qAO);
+    // const _theta = Math.atan2(_B[1], _B[0]) as Radians;
 
-    const qTwist = quat.setAxisAngle(quat.create(), UP, -_theta);
-    vec3.transformQuat(_A, _A, qTwist);
-    vec3.transformQuat(_B, _B, qTwist);
+    // const qTwist = quat.setAxisAngle(quat.create(), UP, -_theta);
+    // vec3.transformQuat(_A, _A, qTwist);
+    // vec3.transformQuat(_B, _B, qTwist);
 
     // Rotate such that B lies it is along x-axis
-    quat.multiply(qAO, qTwist, qAO);
+    //quat.multiply(qAO, qTwist, qAO);
     return qAO;
   }
 
-  getVertexAngles(t: number): [Radians, Radians] {
+  transformVertices(t: number): [Cartesian, Cartesian] {
     const N = this.vertices.length;
     const i = Math.floor(t % N);
     const j = (i + 1) % N;
@@ -124,27 +124,39 @@ export class SphericalPentagonShape {
     const qV = this.getVertexQuat(t);
 
     const _V = vec3.transformQuat(vec3.create(), V, qV);
-    const _A = vec3.transformQuat(vec3.create(), A, qV);
-    const _B = vec3.transformQuat(vec3.create(), B, qV);
+    const _A = vec3.transformQuat(vec3.create(), A, qV) as Cartesian;
+    const _B = vec3.transformQuat(vec3.create(), B, qV) as Cartesian;
+    return [_A, _B];
 
-    const thetaA = Math.atan2(_A[1], _A[0]) as Radians;
-    const thetaB = Math.atan2(_B[1], _B[0]) as Radians;
-    return [thetaA, thetaB];
+    // const thetaA = Math.atan2(_A[1], _A[0]) as Radians;
+    // const thetaB = Math.atan2(_B[1], _B[0]) as Radians;
+    // return [thetaA, thetaB];
   }
 
   containsPoint(point: Cartesian): number {
     const N = this.vertices.length;
-    let thetaDelta = Infinity;
+    console.log(this.vertices)
+    let thetaDeltaMin = Infinity;
     for (let i = 0; i < N; i++) {
       // Transform point into coordinate system of vertex
       const qV = this.getVertexQuat(i);
       const X = vec3.transformQuat(vec3.create(), point, qV);
 
       // Check if point is within vertex angles
-      const vertexAngles = this.getVertexAngles(i);
-      const thetaX = Math.atan2(X[1], X[0]) as Radians;
-      thetaDelta = Math.min(thetaDelta, thetaX - vertexAngles[0], vertexAngles[1] - thetaX);
+      const [A, B] = this.transformVertices(i);
+      A[2] = 0;
+      B[2] = 0;
+      X[2] = 0;
+
+      vec3.normalize(A, A);
+      vec3.normalize(B, B);
+      vec3.normalize(X, X);
+
+      const sinXA = vec3.cross(vec3.create(), X, A)[2];
+      const sinBX = vec3.cross(vec3.create(), B, X)[2];
+
+      thetaDeltaMin = Math.min(thetaDeltaMin, sinXA, sinBX);
     }
-    return thetaDelta;
+    return thetaDeltaMin;
   }
 }

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) A5 contributors
 
-import {vec2, mat2, mat2d, vec3, glMatrix, quat} from 'gl-matrix';
+import {vec3, glMatrix, quat} from 'gl-matrix';
 glMatrix.setMatrixArrayType(Float64Array as any);
-import type { Radians, Spherical, Face, Degrees, LonLat, Cartesian } from './coordinate-systems';
-import { quatFromSpherical, radToDeg, toCartesian, toSpherical } from './coordinate-transforms';
+import type { Cartesian } from './coordinate-systems';
 
+// Use Cartesian system for all calculations for greater accuracy
+// Using [x, y, z] gives equal precision in all directions, unlike spherical coordinates
 export type SphericalPolygon = Cartesian[];
 const UP = [0, 0, 1] as Cartesian;
 

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -16,7 +16,7 @@ export class SphericalPentagonShape {
   constructor(vertices: SphericalPolygon) {
     this.vertices = vertices;
     if (!this.isWindingCorrect()) {
-      debugger;
+      console.log('Winding is incorrect, reversing');
       this.vertices.reverse();
     }
   }
@@ -81,34 +81,6 @@ export class SphericalPentagonShape {
     const out = vec3.fromValues(0, 0, 1);
     vec3.transformQuat(out, out, qCombined);
     return out as Cartesian;
-  }
-
-  getVertexQuat(t: number): quat {
-    const N = this.vertices.length;
-    const i = Math.floor(t % N);
-    const j = (i + 1) % N;
-
-    // Points A & B
-    const A = this.vertices[i];
-    const B = this.vertices[j];
-
-    // Rotation from vertex A to origin (north pole)
-    const qAO = quat.rotationTo(quat.create(), A, UP);
-    const axis = vec3.create();
-    const angle = quat.getAxisAngle(axis, qAO);
-
-    // Rotate B into coordinate system of A
-    // const _A = vec3.transformQuat(vec3.create(), A, qAO);
-    // const _B = vec3.transformQuat(vec3.create(), B, qAO);
-    // const _theta = Math.atan2(_B[1], _B[0]) as Radians;
-
-    // const qTwist = quat.setAxisAngle(quat.create(), UP, -_theta);
-    // vec3.transformQuat(_A, _A, qTwist);
-    // vec3.transformQuat(_B, _B, qTwist);
-
-    // Rotate such that B lies it is along x-axis
-    //quat.multiply(qAO, qTwist, qAO);
-    return qAO;
   }
 
   /**

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -120,14 +120,12 @@ export class SphericalPentagonShape {
 
     const thetaA = Math.atan2(A[1], A[0]) as Radians;
     const thetaB = Math.atan2(B[1], B[0]) as Radians;
-    if (Math.abs(thetaA) > 1e-12) {
-      throw new Error(`thetaA is not near 0: ${thetaA}`);
-    }
     return [thetaA, thetaB];
   }
 
-  containsPoint(point: Spherical): boolean {
+  containsPoint(point: Spherical): number {
     const N = this.vertices.length;
+    let thetaDelta = Infinity;
     for (let i = 0; i < N; i++) {
       // Transform point into coordinate system of vertex
       const X = toCartesian(point);
@@ -137,10 +135,8 @@ export class SphericalPentagonShape {
       // Check if point is within vertex angles
       const vertexAngles = this.getVertexAngles(i);
       const thetaX = Math.atan2(X[1], X[0]) as Radians;
-      if (thetaX < vertexAngles[0] || thetaX > vertexAngles[1]) {
-        return false;
-      }
+      thetaDelta = Math.min(thetaDelta, thetaX - vertexAngles[0], vertexAngles[1] - thetaX);
     }
-    return true;
+    return thetaDelta;
   }
 }

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -7,7 +7,7 @@ glMatrix.setMatrixArrayType(Float64Array as any);
 import type { Radians, Spherical, Face, Degrees, LonLat, Cartesian } from './coordinate-systems';
 import { quatFromSpherical, radToDeg, toCartesian, toSpherical } from './coordinate-transforms';
 
-export type SphericalPolygon = Spherical[];
+export type SphericalPolygon = Cartesian[];
 const UP = [0, 0, 1] as Cartesian;
 
 export class SphericalPentagonShape {
@@ -16,6 +16,7 @@ export class SphericalPentagonShape {
   constructor(vertices: SphericalPolygon) {
     this.vertices = vertices;
     if (!this.isWindingCorrect()) {
+      debugger;
       this.vertices.reverse();
     }
   }
@@ -27,15 +28,24 @@ export class SphericalPentagonShape {
   getArea(): number {
     let signedArea = 0;
     const N = this.vertices.length;
+    
+    // Project vertices onto tangent plane at north pole
+    const projectedVertices = this.vertices.map(v => {
+      const z = vec3.dot(v, UP);
+      return [v[0]/(1+z), v[1]/(1+z)] as [number, number];
+    });
+
+    // Calculate signed area in projected plane
     for (let i = 0; i < N; i++) {
       const j = (i + 1) % N;
-      signedArea += (this.vertices[j][0] - this.vertices[i][0]) * (this.vertices[j][1] + this.vertices[i][1]);
+      signedArea += (projectedVertices[j][0] - projectedVertices[i][0]) * 
+                    (projectedVertices[j][1] + projectedVertices[i][1]);
     }
     return signedArea;
   }
 
-  getBoundary(nSegments: number = 1): Spherical[] {
-    const points: Spherical[] = [];
+  getBoundary(nSegments: number = 1): SphericalPolygon {
+    const points: SphericalPolygon = [];
     const N = this.vertices.length;
     for (let s = 0; s < N * nSegments; s++) {
       const t = s / nSegments;
@@ -49,17 +59,17 @@ export class SphericalPentagonShape {
   /**
    * Interpolates along boundary of polygon. Pass t = 1.5 to get the midpoint between 2nd and 3rd vertices
    * @param t 
-   * @returns Spherical (lat, lon) coordinate
+   * @returns Cartesian coordinate
    */
-  slerp(t: number): Spherical {
+  slerp(t: number): Cartesian {
     const N = this.vertices.length;
     const f = t % 1;
     const i = Math.floor(t % N);
     const j = (i + 1) % N;
 
     // Points A & B
-    const A = toCartesian(this.vertices[i]);
-    const B = toCartesian(this.vertices[j]);
+    const A = this.vertices[i];
+    const B = this.vertices[j];
 
     // Quaternions
     const identity = quat.create();
@@ -70,7 +80,7 @@ export class SphericalPentagonShape {
 
     const out = vec3.fromValues(0, 0, 1);
     vec3.transformQuat(out, out, qCombined);
-    return toSpherical(out as Cartesian);
+    return out as Cartesian;
   }
 
   getVertexQuat(t: number): quat {
@@ -79,8 +89,8 @@ export class SphericalPentagonShape {
     const j = (i + 1) % N;
 
     // Points A & B
-    const A = toCartesian(this.vertices[i]);
-    const B = toCartesian(this.vertices[j]);
+    const A = this.vertices[i];
+    const B = this.vertices[j];
 
     // Rotation from vertex A to origin (north pole)
     const qAO = quat.rotationTo(quat.create(), A, UP);
@@ -89,7 +99,6 @@ export class SphericalPentagonShape {
     const _A = vec3.transformQuat(vec3.create(), A, qAO);
     const _B = vec3.transformQuat(vec3.create(), B, qAO);
     const _theta = Math.atan2(_B[1], _B[0]) as Radians;
-
 
     const qTwist = quat.setAxisAngle(quat.create(), UP, -_theta);
     vec3.transformQuat(_A, _A, qTwist);
@@ -107,30 +116,29 @@ export class SphericalPentagonShape {
     const k = (i + N - 1) % N;
 
     // Points A & B (vertex before and after)
-    const V = toCartesian(this.vertices[i]);
-    const A = toCartesian(this.vertices[j]);
-    const B = toCartesian(this.vertices[k]);
+    const V = this.vertices[i];
+    const A = this.vertices[j];
+    const B = this.vertices[k];
 
     // Quat to rotate into coordinate system of vertex
     const qV = this.getVertexQuat(t);
 
-    vec3.transformQuat(V, V, qV);
-    vec3.transformQuat(A, A, qV);
-    vec3.transformQuat(B, B, qV);
+    const _V = vec3.transformQuat(vec3.create(), V, qV);
+    const _A = vec3.transformQuat(vec3.create(), A, qV);
+    const _B = vec3.transformQuat(vec3.create(), B, qV);
 
-    const thetaA = Math.atan2(A[1], A[0]) as Radians;
-    const thetaB = Math.atan2(B[1], B[0]) as Radians;
+    const thetaA = Math.atan2(_A[1], _A[0]) as Radians;
+    const thetaB = Math.atan2(_B[1], _B[0]) as Radians;
     return [thetaA, thetaB];
   }
 
-  containsPoint(point: Spherical): number {
+  containsPoint(point: Cartesian): number {
     const N = this.vertices.length;
     let thetaDelta = Infinity;
     for (let i = 0; i < N; i++) {
       // Transform point into coordinate system of vertex
-      const X = toCartesian(point);
       const qV = this.getVertexQuat(i);
-      vec3.transformQuat(X, X, qV);
+      const X = vec3.transformQuat(vec3.create(), point, qV);
 
       // Check if point is within vertex angles
       const vertexAngles = this.getVertexAngles(i);

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -21,6 +21,11 @@ export class SphericalPentagonShape {
     }
   }
 
+  /**
+   * 
+   * @param nSegments Returns a close boundary of the polygon, with nSegments points per edge
+   * @returns SphericalPolygon
+   */
   getBoundary(nSegments: number = 1): SphericalPolygon {
     const points: SphericalPolygon = [];
     const N = this.vertices.length;
@@ -83,15 +88,18 @@ export class SphericalPentagonShape {
   }
 
   containsPoint(point: Cartesian): number {
+    // Adaption of algorithm from:
+    // 'Locating a point on a spherical surface relative to a spherical polygon'
+    // Using only the condition of 'necessary strike'
     const N = this.vertices.length;
     let thetaDeltaMin = Infinity;
 
     for (let i = 0; i < N; i++) {
-      // Transform point and neighboring vertices into coordinate system of vertex
+      // Transform point and neighboring vertices into coordinate system centered on vertex
       const [V, VA, VB] = this.getTransformedVertices(i);
       const VP = vec3.sub(vec3.create(), point, V);
 
-      // Normalize direction vectors
+      // Normalize to obtain unit direction vectors
       vec3.normalize(VP, VP);
       vec3.normalize(VA, VA);
       vec3.normalize(VB, VB);

--- a/modules/core/spherical-pentagon.ts
+++ b/modules/core/spherical-pentagon.ts
@@ -16,32 +16,8 @@ export class SphericalPentagonShape {
   constructor(vertices: SphericalPolygon) {
     this.vertices = vertices;
     if (!this.isWindingCorrect()) {
-      console.log('Winding is incorrect, reversing');
       this.vertices.reverse();
     }
-  }
-
-  private isWindingCorrect(): boolean {
-    return this.getArea() >= 0;
-  }
-
-  getArea(): number {
-    let signedArea = 0;
-    const N = this.vertices.length;
-    
-    // Project vertices onto tangent plane at north pole
-    const projectedVertices = this.vertices.map(v => {
-      const z = vec3.dot(v, UP);
-      return [v[0]/(1+z), v[1]/(1+z)] as [number, number];
-    });
-
-    // Calculate signed area in projected plane
-    for (let i = 0; i < N; i++) {
-      const j = (i + 1) % N;
-      signedArea += (projectedVertices[j][0] - projectedVertices[i][0]) * 
-                    (projectedVertices[j][1] + projectedVertices[i][1]);
-    }
-    return signedArea;
   }
 
   getBoundary(nSegments: number = 1): SphericalPolygon {
@@ -138,5 +114,11 @@ export class SphericalPentagonShape {
     // If point is on edge of arc, will return 0
     // If point is outside all arcs, will return -1, the further away from 0, the further away from the arc
     return thetaDeltaMin;
+  }
+
+  private isWindingCorrect(): boolean {
+    const [V, VA, VB] = this.getTransformedVertices(0);
+    const cross = vec3.cross(vec3.create(), VA, VB);
+    return vec3.dot(V, cross) <= 0;
   }
 }

--- a/modules/core/tiling.ts
+++ b/modules/core/tiling.ts
@@ -89,14 +89,6 @@ export function getFaceVertices(): PentagonShape {
   return new PentagonShape(vertices as Pentagon);
 }
 
-
-export function getQuintant(point: vec2): number {
-  // TODO perhaps quicker way without trigonometry
-  const angle = Math.atan2(point[1], point[0]);
-  const normalizedAngle = (angle - V + TWO_PI) % TWO_PI;
-  return Math.ceil(normalizedAngle / TWO_PI_OVER_5) % 5;
-}
-
 export function getQuintantPolar([_, gamma]: Polar): number {
   return (Math.round(gamma / TWO_PI_OVER_5) + 5) % 5;
 }

--- a/tests/cell.test.ts
+++ b/tests/cell.test.ts
@@ -120,6 +120,9 @@ describe('Cell Boundary Tests', () => {
                 
                 // Store failures for this resolution if any occurred
                 if (resolutionFailures.length > 0) {
+                    if (!failures[pointKey]) {
+                        failures[pointKey] = {};
+                    }
                     failures[pointKey][resolution] = resolutionFailures;
                 }
             }

--- a/tests/coordinate-transforms.test.ts
+++ b/tests/coordinate-transforms.test.ts
@@ -5,8 +5,7 @@ import {
   toCartesian,
   toSpherical,
   fromLonLat,
-  toLonLat,
-  lonLatToCartesian
+  toLonLat
 } from 'a5/core/coordinate-transforms'
 import type { Degrees, LonLat, Radians, Spherical } from 'a5/core/coordinate-systems'
 
@@ -97,30 +96,4 @@ describe('LonLat to/from spherical', () => {
       expect(newLat).toBeCloseTo(lat)
     })
   })
-})
-
-describe('LonLat to Cartesian', () => {
-  it('produces unit vectors', () => {
-    // Test that all output vectors have length 1 (within floating point precision)
-    TEST_POINTS.forEach(point => {
-      const cartesian = lonLatToCartesian(point)
-      const length = Math.sqrt(
-        cartesian[0] * cartesian[0] + 
-        cartesian[1] * cartesian[1] + 
-        cartesian[2] * cartesian[2]
-      )
-      expect(length).toBeCloseTo(1)
-    })
-  })
-
-  it('matches composition of fromLonLat and toCartesian', () => {
-    // Test that lonLatToCartesian gives same results as fromLonLat -> toCartesian
-    TEST_POINTS.forEach(point => {
-      const direct = lonLatToCartesian(point)
-      const composed = toCartesian(fromLonLat(point))
-      expect(direct[0]).toBeCloseTo(composed[0])
-      expect(direct[1]).toBeCloseTo(composed[1])
-      expect(direct[2]).toBeCloseTo(composed[2])
-    })
-  })
-}) 
+});

--- a/tests/coordinate-transforms.test.ts
+++ b/tests/coordinate-transforms.test.ts
@@ -5,9 +5,24 @@ import {
   toCartesian,
   toSpherical,
   fromLonLat,
-  toLonLat
+  toLonLat,
+  lonLatToCartesian
 } from 'a5/core/coordinate-transforms'
 import type { Degrees, LonLat, Radians, Spherical } from 'a5/core/coordinate-systems'
+
+const TEST_POINTS: Array<LonLat> = [
+  [0, 0],     // Equator
+  [90, 0],    // Equator
+  [180, 0],   // Equator
+  [0, 45],    // Mid latitude
+  [0, -45],   // Mid latitude
+  [-90, -45], // West hemisphere mid-latitude
+  [180, 45],  // Date line mid-latitude
+  [90, 45],   // East hemisphere mid-latitude
+  [0, 90],    // North pole
+  [0, -90],   // South pole
+  [123, 45],  // Arbitrary point
+] as LonLat[];
 
 describe('angle conversions', () => {
   it('converts degrees to radians', () => {
@@ -74,20 +89,38 @@ describe('LonLat to/from spherical', () => {
 
   it('converts spherical to longitude/latitude coordinates', () => {
     // Test round trip conversion
-    const TEST_POINTS: Array<[number, number]> = [
-      [0, 0],     // Greenwich equator
-      [0, 90],    // North pole
-      [0, -90],   // South pole
-      [180, 45],  // Date line mid-latitude
-      [-90, -45], // West hemisphere mid-latitude
-    ];
-
     TEST_POINTS.forEach(([lon, lat]) => {
       const spherical = fromLonLat([lon, lat] as LonLat)
       const [newLon, newLat] = toLonLat(spherical)
       
       expect(newLon).toBeCloseTo(lon)
       expect(newLat).toBeCloseTo(lat)
+    })
+  })
+})
+
+describe('LonLat to Cartesian', () => {
+  it('produces unit vectors', () => {
+    // Test that all output vectors have length 1 (within floating point precision)
+    TEST_POINTS.forEach(point => {
+      const cartesian = lonLatToCartesian(point)
+      const length = Math.sqrt(
+        cartesian[0] * cartesian[0] + 
+        cartesian[1] * cartesian[1] + 
+        cartesian[2] * cartesian[2]
+      )
+      expect(length).toBeCloseTo(1)
+    })
+  })
+
+  it('matches composition of fromLonLat and toCartesian', () => {
+    // Test that lonLatToCartesian gives same results as fromLonLat -> toCartesian
+    TEST_POINTS.forEach(point => {
+      const direct = lonLatToCartesian(point)
+      const composed = toCartesian(fromLonLat(point))
+      expect(direct[0]).toBeCloseTo(composed[0])
+      expect(direct[1]).toBeCloseTo(composed[1])
+      expect(direct[2]).toBeCloseTo(composed[2])
     })
   })
 }) 

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -13,7 +13,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Technical',
-      items: ['pentagon', 'teohedron-dodecahedron', 'lattice', 'hilbert', 'globe']
+      items: ['pentagon', 'teohedron-dodecahedron', 'spherical-polygon', 'lattice', 'hilbert', 'globe']
     },
     {
       type: 'category',

--- a/website/src/examples/spherical-polygon.js
+++ b/website/src/examples/spherical-polygon.js
@@ -1,0 +1,32 @@
+import React, {Component} from 'react';
+import {GITHUB_TREE} from '../constants/defaults';
+import App from 'website-examples/spherical-polygon/app';
+
+import {makeExample} from '../components';
+
+class SphericalPolygonDemo extends Component {
+  static title = 'Spherical Polygon';
+
+  static code = `${GITHUB_TREE}/examples/website/spherical-polygon`;
+
+  static parameters = {};
+
+  static renderInfo(meta) {
+    return (
+      <div>
+        <p>Visualization of a hit-testing of spherical polygons on the globe.</p>
+        <p>Rotate the globe to move the hit-testing point.</p>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div style={{width: '100%', height: '100%', position: 'absolute', background: '#111'}}>
+        <App {...this.props} />
+      </div>
+    );
+  }
+}
+
+export default makeExample(SphericalPolygonDemo); 

--- a/website/src/examples/spherical-polygon.mdx
+++ b/website/src/examples/spherical-polygon.mdx
@@ -1,0 +1,5 @@
+# Spherical Polygon
+
+import Demo from './spherical-polygon';
+
+<Demo /> 


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

Better containsPoint implementation using spherical polygons

<!-- For all the PRs -->
#### Change List
- Remove `reprojectPentagon` added in previous [PR](https://github.com/felixpalmer/a5/pull/25)
- New `SphericalPentagonShape` class for accurate hit testing
- New test app for visualizing the hit testing
