### PR TITLE
Use authalic latitude

### DIFF
--- a/examples/cli/wireframe/README.md
+++ b/examples/cli/wireframe/README.md
@@ -1,0 +1,15 @@
+# A5 Wireframe CLI Tool
+
+This CLI tool generates all cells at a given resolution, outputting as GeoJSON
+
+## Installation
+
+```bash
+npm install
+```
+
+## Usage
+
+```bash
+node index.js <resolution> <output.json>
+```

--- a/examples/cli/wireframe/area_stats.sh
+++ b/examples/cli/wireframe/area_stats.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+AUTHALIC_EARTH_AREA=510065624.77943915
+KM_PER_M=0.000001
+
+node index.js $1 cells.geojson
+
+ogrinfo -q -dialect SQLite -sql "
+WITH stats AS (
+  SELECT
+    $KM_PER_M * MIN(ST_Area(geometry,1)) as min_area,
+    $KM_PER_M * MAX(ST_Area(geometry,1)) as max_area,
+    $AUTHALIC_EARTH_AREA / COUNT(geometry) as authalic_average
+  FROM cells
+),
+error_calc AS (
+  SELECT 
+    ROUND(((max_area / authalic_average) - 1) * 100, 5) || '%' as max_error
+  FROM stats
+)
+SELECT * FROM error_calc
+" cells.geojson | grep "max_error" | awk -F "= " '{print "Area Error: " $2}'
+
+rm cells.geojson

--- a/examples/cli/wireframe/calculate_error_budgets.sh
+++ b/examples/cli/wireframe/calculate_error_budgets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Calculating area errors for resolutions 1-8..."
+echo
+
+for res in {1..8}
+do
+  echo -n "Resolution $res: "
+  ./area_stats.sh $res
+done 

--- a/examples/cli/wireframe/index.js
+++ b/examples/cli/wireframe/index.js
@@ -1,0 +1,55 @@
+const {
+  cellToBoundary,
+  bigIntToHex,
+  cellToChildren,
+} = require("../../../dist/a5.cjs");
+const fs = require("fs");
+
+const resolution = parseInt(process.argv[2]);
+const outputFile = process.argv[3];
+
+if (!outputFile || isNaN(resolution)) {
+  console.error("Usage: node index.js <resolution> <output.json>");
+  console.error("  resolution: A5 cell resolution (integer)");
+  process.exit(1);
+}
+
+const cells = [];
+try {
+  // Calculate total number of cells at this resolution
+  const cellIds = cellToChildren(0n, resolution);
+
+  // Generate all cells
+  for (let cellId of cellIds) {
+    const cellIdHex = bigIntToHex(cellId);
+    const boundary = cellToBoundary(cellId, {
+      closedRing: true,
+      segments: "auto",
+    });
+
+    cells.push({
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [boundary],
+      },
+    });
+  }
+
+  // Create GeoJSON FeatureCollection
+  const geojson = {
+    type: "FeatureCollection",
+    features: cells,
+  };
+
+  // Write to JSON file
+  fs.writeFileSync(outputFile, JSON.stringify(geojson, null, 2));
+
+  console.log(
+    `Successfully generated ${cells.length} A5 cells at resolution ${resolution}`
+  );
+  console.log(`Output written to ${outputFile}`);
+} catch (error) {
+  console.error("Error generating cells:", error);
+  process.exit(1);
+}

--- a/examples/cli/wireframe/package.json
+++ b/examples/cli/wireframe/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "a5-wireframe-cli",
+  "version": "1.0.0",
+  "description": "CLI tool to generate all cells at given resolution",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "a5-js": "latest"
+  }
+} 

--- a/modules/core/coordinate-transforms.ts
+++ b/modules/core/coordinate-transforms.ts
@@ -6,6 +6,7 @@ import { vec2, quat, glMatrix } from 'gl-matrix';
 glMatrix.setMatrixArrayType(Float64Array as any);
 import type { Degrees, Radians, Face, Polar, IJ, Cartesian, Spherical, LonLat } from "./coordinate-systems";
 import { BASIS_INVERSE, BASIS } from "./pentagon";
+import { geodeticToAuthalic, authalicToGeodetic } from "./authalic";
 
 export function degToRad(deg: Degrees): Radians {
   return deg * (Math.PI / 180) as Radians;
@@ -67,7 +68,10 @@ const LONGITUDE_OFFSET = 93 as Degrees;
  */
 export function fromLonLat([longitude, latitude]: LonLat): Spherical {
   const theta = degToRad(longitude + LONGITUDE_OFFSET as Degrees);
-  const phi = degToRad((90 - latitude) as Degrees);
+  
+  const geodeticLat = degToRad(latitude as Degrees);
+  const authalicLat = geodeticToAuthalic(geodeticLat);
+  const phi = (Math.PI / 2 - authalicLat) as Radians;
   return [theta, phi] as Spherical;
 }
 
@@ -79,7 +83,10 @@ export function fromLonLat([longitude, latitude]: LonLat): Spherical {
  */
 export function toLonLat([theta, phi]: Spherical): LonLat {
   const longitude = radToDeg(theta) - LONGITUDE_OFFSET as Degrees;
-  const latitude = (90 - radToDeg(phi)) as Degrees;
+
+  const authalicLat = Math.PI / 2 - phi as Radians;
+  const geodeticLat = authalicToGeodetic(authalicLat);
+  const latitude = radToDeg(geodeticLat) as Degrees;
   return [longitude, latitude] as LonLat;
 }
 


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

Actually enables the authalic to/from conversion. Also adds a cli app for examining the output cell areas using GDAL, to calculate the maximum cell area error:

```
Resolution 1: Successfully generated 12 A5 cells at resolution 1
Area Error: 0.0%
Resolution 2: Successfully generated 60 A5 cells at resolution 2
Area Error: 3.0e-05%
Resolution 3: Successfully generated 240 A5 cells at resolution 3
Area Error: 0.85594%
Resolution 4: Successfully generated 960 A5 cells at resolution 4
Area Error: 0.73536%
Resolution 5: Successfully generated 3840 A5 cells at resolution 5
Area Error: 0.58161%
Resolution 6: Successfully generated 15360 A5 cells at resolution 6
Area Error: 0.47976%
Resolution 7: Successfully generated 61440 A5 cells at resolution 7
Area Error: 0.4285%
Resolution 8: Successfully generated 245760 A5 cells at resolution 8
Area Error: 0.40674%
```

The error is always below 1%, thus fulfulling the OGC criterion for an Equal Area DGGS

<!-- For all the PRs -->
#### Change List
- Wireframe CLI app
- Use authalic conversion in `fromLonLat` and `toLonLat`
