### PR TITLE
calculate_error_budgets: stochastic sampling

### DIFF
--- a/examples/cli/wireframe/area_stats.sh
+++ b/examples/cli/wireframe/area_stats.sh
@@ -10,7 +10,12 @@ WITH stats AS (
   SELECT
     $KM_PER_M * MIN(ST_Area(geometry,1)) as min_area,
     $KM_PER_M * MAX(ST_Area(geometry,1)) as max_area,
-    $AUTHALIC_EARTH_AREA / COUNT(geometry) as authalic_average
+    $AUTHALIC_EARTH_AREA / (
+      CASE 
+        WHEN $1 = 0 THEN 12
+        ELSE 60 * POWER(4, $1 - 1)
+      END
+    ) as authalic_average
   FROM cells
 ),
 error_calc AS (

--- a/examples/cli/wireframe/calculate_error_budgets.sh
+++ b/examples/cli/wireframe/calculate_error_budgets.sh
@@ -3,7 +3,7 @@
 echo "Calculating area errors for resolutions 1-8..."
 echo
 
-for res in {1..8}
+for res in {0..10}
 do
   echo -n "Resolution $res: "
   ./area_stats.sh $res

--- a/examples/cli/wireframe/index.js
+++ b/examples/cli/wireframe/index.js
@@ -17,14 +17,31 @@ if (!outputFile || isNaN(resolution)) {
 const cells = [];
 try {
   // Calculate total number of cells at this resolution
-  const cellIds = cellToChildren(0n, resolution);
+  const LIMIT = 10000;
+  let cellIds = cellToChildren(0n, 1);
+  let r = 1;
+  while (r < resolution) {
+    r++;
+    const newCellIds = [];
+    const probability = LIMIT / (cellIds.length * 4);
+    for (const c of cellIds) {
+      let children = cellToChildren(c, r);
+      for (const c of children) {
+        if (Math.random() < probability) {
+          newCellIds.push(c);
+        }
+      }
+    }
+
+    cellIds = newCellIds;
+  }
 
   // Generate all cells
   for (let cellId of cellIds) {
     const cellIdHex = bigIntToHex(cellId);
     const boundary = cellToBoundary(cellId, {
       closedRing: true,
-      segments: "auto",
+      segments: 10,
     });
 
     cells.push({


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

When generating cells using `area_stats.sh` at a high resolution, the number of output cells can become very high. By sampling stochastically, we can get an estimate without exploding

<!-- For all the PRs -->
#### Change List
- Stochastic sampling in `calculate_error_budgets.sh` helper
