### PR TITLE
 Rename bigIntToHex to u64ToHex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Change Log
+
+All notable changes to A5 will be documented in this file.
+
+For the latest documentation, visit [A5 Documentation](https://a5.felixpalmer.com)
+
+<!--
+Each version should:
+  List its release date in the above format.
+  Group changes to describe their impact on the project, as follows:
+  Added for new features.
+  Changed for changes in existing functionality.
+  Deprecated for once-stable features removed in upcoming releases.
+  Removed for deprecated features removed in this release.
+  Fixed for any bug fixes.
+  Security to invite users to upgrade in case of vulnerabilities.
+Ref: http://keepachangelog.com/en/0.3.0/
+-->
+
+## A5 v0.5
+
+#### A5 [v0.5.0] - Sep 21 2025
+
+- **BREAKING**: Renamed hex conversion functions to use u64 naming convention
+  - `hexToBigInt` → `hexToU64`
+  - `bigIntToHex` → `u64ToHex`
+
+## A5 v0.4
+
+#### A5 [v0.4.2] - Aug 7 2025
+
+- Fixed: cellToChildren and cellToParent functions (#52)
+- Added: JavaScript and Python quickstarts to website (#51)
+
+#### A5 [v0.4.1] - Jul 30 2025
+
+- Fixed: Containment check in lattice app (#50)
+- Added: Tiling tests (#49)
+- Changed: Tidy geometry pentagon (#48)
+- Fixed: a5cellContainsPoint check in projected space (#47)
+- Changed: Improve accuracy of origin.quat definitions (#46)
+
+#### A5 [v0.4.0] - Jul 15 2025
+
+- Changed: Tidy geometry classes and tests (#45)
+- Changed: calculate_error_budgets: stochastic sampling (#44)
+- Added: getRes0Cells, cellArea & getNumCells functions (#43)
+
+## A5 v0.3
+
+#### A5 [v0.3.0] - Jul 13 2025
+
+- Changed: Refactor of projection tests & test data (#42)
+- Changed: Update heatmap data (#41)
+- Added: Static CRS to improve projection accuracy (#40)
+- Added: Integration fixtures (#39)
+- Changed: Area calculation cleanup (#38)
+- Added: True equal area polyhedral projection (#37)
+- Changed: Website tweaks (#34)
+- Added: Missing tests & general integration test (#33)
+- Changed: Update heatmap data with authalic projection (#32)
+
+## A5 v0.2
+
+#### A5 [v0.2.0] - Jun 10 2025
+
+- Added: Use authalic latitude (#31)
+- Changed: Low/high warp parameters (#30)
+- Added: Curved edge segments & GeoJSON output format (#29)
+- Changed: Tweak warp parameters (#28)
+- Changed: Update traffic data (#27)
+- Added: SphericalPentagonShape & test app (#26)
+- Changed: Better point in pentagon test (#25)
+- Added: Test fixed places (#24)
+- Changed: Update cell.test.ts (#23)
+- Changed: Update curve such that child cells overlap parent (#22)
+- Added: Authalic conversion functions (#21)
+- Added: Dependency analysis (#20)
+- Changed: Rename coordinate systems files (#19)
+- Changed: Update warp tests (#18)
+- Added: CI workflow to check that website will build (#17)
+- Added: Setup PR template and CI testing (#16)
+- Changed: Cleanup imports to avoid circular dependencies
+
+## A5 v0.1
+
+#### A5 [v0.1.3] - May 16 2025
+
+- Fixed: Remove browser from package.json
+
+#### A5 [v0.1.2] - May 16 2025
+
+- Fixed: Package compatibility issues
+
+#### A5 [v0.1.1] - May 16 2025
+
+- Fixed: Better package compatibility
+
+#### A5 [v0.1.0] - May 16 2025
+
+- Added: Initial release of A5 - Global Pentagonal Geospatial Index
+- Added: Core indexing functions (lonLatToCell, cellToLonLat, cellToBoundary)
+- Added: Hierarchy functions (cellToParent, cellToChildren, getResolution)
+- Added: Hex conversion utilities
+- Added: Complete projection system with authalic, gnomonic, and polyhedral projections
+- Added: Geometry utilities for pentagon and spherical polygon operations
+- Added: Comprehensive test suite
+- Added: TypeScript support with full type definitions
+- Added: Multiple output formats (ESM, CJS, UMD)

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -9,8 +9,8 @@ For examples on how to use the code, see the [example code on Github](https://gi
 - [lonLatToCell](./api-reference/indexing#lonlattocell)
 - [cellToLonLat](./api-reference/indexing#celltolonlat)
 - [cellToBoundary](./api-reference/indexing#celltoboundary)
-- [bigIntToHex](./api-reference/indexing#biginttohex)
-- [hexToBigInt](./api-reference/indexing#hextobigint)
+- [u64ToHex](./api-reference/indexing#u64tohex)
+- [hexToU64](./api-reference/indexing#hextou64)
 
 ### Hierarchy
 

--- a/docs/api-reference/indexing.md
+++ b/docs/api-reference/indexing.md
@@ -65,10 +65,10 @@ A5 cells are stored as 64 bit integers, for performance and to provide a compact
 
 For best performance it is recommened to use this representation, but it is also possible to convert them into hexidecimal, for example to encode them in JSON (which does _not_ support 64 bit integers). Two helper functions are provided for this conversion.
 
-### bigIntToHex
+### u64ToHex
 
 ```ts
-function bigIntToHex(index: bigint): string;
+function u64ToHex(index: bigint): string;
 ```
 
 #### Parameters
@@ -79,10 +79,10 @@ function bigIntToHex(index: bigint): string;
 
 - **(string)** Hexadecimal string representation of the cell identifier
 
-### hexToBigInt
+### hexToU64
 
 ```ts
-function hexToBigInt(hex: string): bigint;
+function hexToU64(hex: string): bigint;
 ```
 
 #### Parameters

--- a/docs/quickstart/javascript.md
+++ b/docs/quickstart/javascript.md
@@ -21,7 +21,7 @@ yarn add a5-js
 Here's a complete example that generates A5 cells at a specified resolution and outputs them as GeoJSON:
 
 ```javascript
-import { cellToBoundary, bigIntToHex, cellToChildren } from "a5-js";
+import { cellToBoundary, u64ToHex, cellToChildren } from "a5-js";
 
 // Generate all cells at the specified resolution
 const resolution = 2;
@@ -30,7 +30,7 @@ const cellIds = cellToChildren(0n, resolution);
 
 // Generate boundary for each cell
 for (let cellId of cellIds) {
-  const cellIdHex = bigIntToHex(cellId);
+  const cellIdHex = u64ToHex(cellId);
   const boundary = cellToBoundary(cellId);
 
   cells.push({

--- a/examples/cli/aggregate/index.js
+++ b/examples/cli/aggregate/index.js
@@ -1,5 +1,5 @@
 const { parse } = require('csv-parse/sync');
-const { lonLatToCell, cellToLonLat, bigIntToHex } = require('a5-js');
+const { lonLatToCell, cellToLonLat, u64ToHex } = require('a5-js');
 const fs = require('fs');
 
 // Read and parse the CSV file
@@ -34,7 +34,7 @@ try {
     }
 
     const cellId = lonLatToCell([lng, lat], resolution);
-    const cellIdHex = bigIntToHex(cellId);
+    const cellIdHex = u64ToHex(cellId);
 
     if (!aggregatedData.has(cellIdHex)) {
       aggregatedData.set(cellIdHex, {

--- a/examples/cli/cross-check/index.js
+++ b/examples/cli/cross-check/index.js
@@ -1,6 +1,6 @@
 const {
   cellToBoundary,
-  bigIntToHex,
+  u64ToHex,
   cellToChildren,
 } = require("../../../dist/a5.cjs");
 const fs = require("fs");
@@ -50,7 +50,7 @@ function generateTypeScriptOutput() {
 
     // Generate all cells
     for (let cellId of cellIds) {
-      const cellIdHex = bigIntToHex(cellId);
+      const cellIdHex = u64ToHex(cellId);
       const boundary = cellToBoundary(cellId, {
         closedRing: true,
         segments: 1,

--- a/examples/cli/wireframe/index.js
+++ b/examples/cli/wireframe/index.js
@@ -1,6 +1,6 @@
 const {
   cellToBoundary,
-  bigIntToHex,
+  u64ToHex,
   cellToChildren,
 } = require("../../../dist/a5.cjs");
 const fs = require("fs");
@@ -38,7 +38,7 @@ try {
 
   // Generate all cells
   for (let cellId of cellIds) {
-    const cellIdHex = bigIntToHex(cellId);
+    const cellIdHex = u64ToHex(cellId);
     const boundary = cellToBoundary(cellId, {
       closedRing: true,
       segments: 10,

--- a/examples/website/road-safety/app.tsx
+++ b/examples/website/road-safety/app.tsx
@@ -4,7 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import {Map as Maplibre, useControl} from 'react-map-gl/maplibre';
 import {MapboxOverlay as DeckOverlay} from '@deck.gl/mapbox';
 import {PolygonLayer} from '@deck.gl/layers';
-import { cellToBoundary, hexToBigInt } from 'a5';
+import { cellToBoundary, hexToU64 } from 'a5';
 import { Color } from '@deck.gl/core';
 
 const HEATMAP_DATA = '/data/heatmap-data.json';
@@ -25,7 +25,7 @@ const App: React.FC = () => {
   const cellLayer = new PolygonLayer<A5CellWithCount>({
     data: HEATMAP_DATA,
     id: 'cell-polygon',
-    getPolygon: d => cellToBoundary(hexToBigInt(d.cellId)),
+    getPolygon: d => cellToBoundary(hexToU64(d.cellId)),
     getFillColor: (d: A5CellWithCount) => {
       // Interpolate between A5 green and white based on sqrt of count
       const scale = Math.sqrt(d.count / MAX_COUNT);

--- a/examples/website/wireframe/app.tsx
+++ b/examples/website/wireframe/app.tsx
@@ -3,7 +3,7 @@ import {createRoot} from 'react-dom/client';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import {Map} from 'react-map-gl/maplibre';
 import {PolygonLayer} from '@deck.gl/layers';
-import {cellToBoundary, bigIntToHex, cellToChildren} from 'a5';
+import {cellToBoundary, u64ToHex, cellToChildren} from 'a5';
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
 
@@ -34,7 +34,7 @@ const App: React.FC<{showControls?: boolean}> = ({showControls = true}) => {
       const boundary = cellToBoundary(cellId);
       return {
         polygon: [boundary],
-        cellId: bigIntToHex(cellId)
+        cellId: u64ToHex(cellId)
       };
     });
   }, [resolution]);

--- a/modules/core/hex.ts
+++ b/modules/core/hex.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) A5 contributors
 
-export function hexToBigInt(hex: string): bigint {
+export function hexToU64(hex: string): bigint {
   return BigInt(`0x${hex}`);
 }
   
-export function bigIntToHex(index: bigint): string {
+export function u64ToHex(index: bigint): string {
   return index.toString(16);
 }

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -8,7 +8,7 @@ glMatrix.setMatrixArrayType(Float64Array as any);
 // PUBLIC API
 // Indexing
 export {cellToBoundary, cellToLonLat, lonLatToCell} from './core/cell';
-export {hexToBigInt, bigIntToHex} from './core/hex';
+export {hexToU64, u64ToHex} from './core/hex';
 
 // Hierarchy
 export {cellToParent, cellToChildren, getResolution, getRes0Cells} from './core/serialization';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a5-js",
   "description": "A5 - Global Pentagonal Geospatial Index",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/scripts/generate-wireframe-tests.cjs
+++ b/scripts/generate-wireframe-tests.cjs
@@ -1,4 +1,4 @@
-const { cellToBoundary, bigIntToHex, cellToChildren } = require("../dist/a5.cjs");
+const { cellToBoundary, u64ToHex, cellToChildren } = require("../dist/a5.cjs");
 const fs = require("fs");
 const path = require("path");
 
@@ -14,7 +14,7 @@ function generateWireframeTest(resolution, segments = "auto") {
     // Generate all cells at a given resolution
     const cellIds = cellToChildren(0n, resolution);
     for (let cellId of cellIds) {
-      const cellIdHex = bigIntToHex(cellId);
+      const cellIdHex = u64ToHex(cellId);
       const boundary = cellToBoundary(cellId, { closedRing: true, segments });
 
       features.push({

--- a/tests/cell.test.ts
+++ b/tests/cell.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type {Degrees,LonLat } from "a5/core/coordinate-systems";
 import { cellToBoundary, cellToLonLat, lonLatToCell,a5cellContainsPoint } from 'a5/core/cell'
 import { deserialize, MAX_RESOLUTION } from 'a5/core/serialization';
-import { hexToBigInt } from 'a5/core/hex';
+import { hexToU64 } from 'a5/core/hex';
 import populatedPlaces from './data/ne_50m_populated_places_nameonly.json';
 
 interface GeoJSONFeature {
@@ -70,7 +70,7 @@ describe('Antimeridian Cell Tests', () => {
     it('Antimeridian cell should have longitude span less than 180 degrees', () => {
         for (const cellId of antimeridianCells) {
             for (const segment of segments) {
-                const cellIdBigInt = hexToBigInt(cellId);
+                const cellIdBigInt = hexToU64(cellId);
                 const boundary = cellToBoundary(cellIdBigInt, {segments: segment as number});
 
                 // Check for antimeridian crossing

--- a/tests/hex.test.ts
+++ b/tests/hex.test.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect } from 'vitest'
-import { hexToBigInt, bigIntToHex } from 'a5/core/hex'
+import { hexToU64, u64ToHex } from 'a5/core/hex'
 
 describe('hex.ts', () => {
-  describe('hexToBigInt', () => {
+  describe('hexToU64', () => {
     it('converts hex strings to BigInt', () => {
-      expect(hexToBigInt('1a2b3c')).toBe(BigInt(1715004));
-      expect(hexToBigInt('0')).toBe(BigInt(0));
-      expect(hexToBigInt('ff')).toBe(BigInt(255));
-      expect(hexToBigInt('ffffffff')).toBe(BigInt(4294967295));
+      expect(hexToU64('1a2b3c')).toBe(BigInt(1715004));
+      expect(hexToU64('0')).toBe(BigInt(0));
+      expect(hexToU64('ff')).toBe(BigInt(255));
+      expect(hexToU64('ffffffff')).toBe(BigInt(4294967295));
     });
   });
 
-  describe('bigIntToHex', () => {
+  describe('u64ToHex', () => {
     it('converts BigInt to hex strings', () => {
-      expect(bigIntToHex(BigInt(1715004))).toBe('1a2b3c');
-      expect(bigIntToHex(BigInt(0))).toBe('0');
-      expect(bigIntToHex(BigInt(255))).toBe('ff');
-      expect(bigIntToHex(BigInt(4294967295))).toBe('ffffffff');
+      expect(u64ToHex(BigInt(1715004))).toBe('1a2b3c');
+      expect(u64ToHex(BigInt(0))).toBe('0');
+      expect(u64ToHex(BigInt(255))).toBe('ff');
+      expect(u64ToHex(BigInt(4294967295))).toBe('ffffffff');
     });
   });
 
@@ -25,8 +25,8 @@ describe('hex.ts', () => {
       const testValues = ['1a2b3c', '0', 'ff', 'ffffffff'];
       
       for (const hexStr of testValues) {
-        const bigInt = hexToBigInt(hexStr);
-        const result = bigIntToHex(bigInt);
+        const bigInt = hexToU64(hexStr);
+        const result = u64ToHex(bigInt);
         expect(result).toBe(hexStr);
       }
     });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { cellToBoundary } from 'a5/core/cell'
-import { hexToBigInt } from 'a5/core/hex'
+import { hexToU64 } from 'a5/core/hex'
 import type { LonLat } from 'a5/core/coordinate-systems'
 
 // Import test data
@@ -53,7 +53,7 @@ describe('wireframe integration tests', () => {
         const expectedBoundary = feature.geometry.coordinates[0];
         
         // Get the boundary from cellToBoundary
-        const cellId = hexToBigInt(cellIdHex);
+        const cellId = hexToU64(cellIdHex);
         const actualBoundary = cellToBoundary(cellId, { closedRing: true, segments });
 
         // Compare the boundaries

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -4,7 +4,7 @@ import { A5Cell } from 'a5/core/utils';
 import { origins } from 'a5/core/origin';
 import TEST_IDS from './test-ids.json';
 import { cellToParent, cellToChildren } from 'a5/core/serialization';
-import { bigIntToHex } from 'a5/core/hex';
+import { u64ToHex } from 'a5/core/hex';
 
 const RESOLUTION_MASKS = [
   // Non-Hilbert resolutions
@@ -270,7 +270,7 @@ describe('getRes0Cells', () => {
     
     // Verify each cell matches the expected hex value
     res0Cells.forEach((cell, index) => {
-      expect(bigIntToHex(cell)).toBe(expectedHexValues[index]);
+      expect(u64ToHex(cell)).toBe(expectedHexValues[index]);
     });
   });
 });


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

Aligns API with Rust & Python versions. The fact that BigInt is used is a JavaScript quirk, the value is always a 64bit integer

<!-- For all the PRs -->
#### Change List
- Rename `bigIntToHex` to `u64ToHex`
- Update tests & docs
- Add changelog
