### PR TITLE
Refactor: lattice boundary helpers

### DIFF
--- a/modules/core/cell.ts
+++ b/modules/core/cell.ts
@@ -9,7 +9,7 @@ import type { Face, LonLat, Spherical } from "./coordinate-systems";
 import { FaceToIJ, fromLonLat, toLonLat, toPolar, normalizeLongitudes } from "./coordinate-transforms";
 import { findNearestOrigin, quintantToSegment, segmentToQuintant } from "./origin";
 import { DodecahedronProjection } from "../projections/dodecahedron";
-import { A5Cell } from "./utils";
+import { A5Cell, OriginId } from "./utils";
 import { PentagonShape } from "../geometry/pentagon";
 import { getFaceVertices, getPentagonVertices, getQuintantPolar, getQuintantVertices } from "./tiling";
 import { PI_OVER_5 } from "./constants";
@@ -19,6 +19,24 @@ import { deserialize, serialize, FIRST_HILBERT_RESOLUTION, WORLD_CELL } from "./
 // Reuse these objects to avoid allocation
 const rotation = mat2.create();
 const dodecahedron = new DodecahedronProjection();
+
+// Single-entry cache of the most recent successful lookup. Speeds up
+// dense-sample workloads (polygon boundary tracing, line tracing) where
+// consecutive calls often land in the same cell. The cache stores the
+// pre-computed pentagon + origin so the hit-test is just one projection
+// + one pentagon containment check.
+let _lastResult: {
+  cellId: bigint,
+  pentagon: PentagonShape,
+  originId: OriginId,
+  resolution: number,
+} | null = null;
+
+/** Update the single-entry cache with a successful (cell, cellId) pair. */
+function cacheResult(cell: A5Cell, cellId: bigint, resolution: number): bigint {
+  _lastResult = {cellId, pentagon: _getPentagon(cell), originId: cell.origin.id, resolution};
+  return cellId;
+}
 
 export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
   // Resolution -1 represents WORLD_CELL, which covers the entire world
@@ -31,43 +49,47 @@ export function lonLatToCell(lonLat: LonLat, resolution: number): bigint {
     return serialize(_lonLatToEstimate(lonLat, resolution));
   }
 
+  // Try the cached pentagon first — skips the full estimate pipeline when
+  // consecutive calls land in the same cell (common in dense-sample loops).
+  if (_lastResult && _lastResult.resolution === resolution) {
+    const projected = dodecahedron.forward(fromLonLat(lonLat), _lastResult.originId);
+    if (_lastResult.pentagon.containsPoint(projected as Face) > 0) return _lastResult.cellId;
+  }
+
+  // Try the original point's projection-based estimate. Common case for
+  // non-boundary points.
+  const firstEstimate = _lonLatToEstimate(lonLat, resolution);
+  const firstKey = serialize(firstEstimate);
+  const firstDistance = a5cellContainsPoint(firstEstimate, lonLat);
+  if (firstDistance > 0) return cacheResult(firstEstimate, firstKey, resolution);
+
+  // Spiral search: perturb lonLat to find nearby estimate cells (the projection
+  // approximation can land in a neighbor at pentagon boundaries). Samples are
+  // generated lazily — if the first sample hits we skip 25 trig+alloc ops.
   const hilbertResolution = 1 + resolution - FIRST_HILBERT_RESOLUTION;
-  const samples: LonLat[] = [lonLat];
   const N = 25;
   const scale = 50 / Math.pow(2, hilbertResolution);
-  for (let i = 0; i < N; i++) {
+  const estimateSet = new Set<bigint>([firstKey]);
+  const cells: {cell: A5Cell, distance: number}[] = [{cell: firstEstimate, distance: firstDistance}];
+
+  // i=0 yields R=0 → same as the original sample, so start at i=1.
+  for (let i = 1; i < N; i++) {
     const R = (i / N) * scale;
-    const coordinate = vec2.fromValues(Math.cos(i) * R, Math.sin(i) * R);
-    vec2.add(coordinate, coordinate, lonLat);
-    samples.push(coordinate as LonLat);
-  }
-
-  // Deduplicate estimates
-  const estimateSet = new Set<bigint>();
-  const uniqueEstimates: A5Cell[] = [];
-
-  const cells: {cell: A5Cell, distance: number}[] = [];
-  for (const sample of samples) {
+    const sample: LonLat = [lonLat[0] + Math.cos(i) * R, lonLat[1] + Math.sin(i) * R] as LonLat;
     const estimate = _lonLatToEstimate(sample, resolution);
     const estimateKey = serialize(estimate);
-    if (!estimateSet.has(estimateKey)) {
-      // Have new estimate, add to set and list
-      estimateSet.add(estimateKey);
-      uniqueEstimates.push(estimate);
-
-      // Check if we have a hit, storing distance if not
-      const distance = a5cellContainsPoint(estimate, lonLat);
-      if (distance > 0) {
-        return serialize(estimate);
-      } else {
-        cells.push({cell: estimate, distance});
-      }
-    }
+    if (estimateSet.has(estimateKey)) continue;
+    estimateSet.add(estimateKey);
+    const distance = a5cellContainsPoint(estimate, lonLat);
+    if (distance > 0) return cacheResult(estimate, estimateKey, resolution);
+    cells.push({cell: estimate, distance});
   }
 
-  // As fallback, sort cells by distance and use the closest one
+  // Fallback: pick the closest estimate. Cache it so subsequent dense-sample
+  // calls still benefit even though this lookup was approximate.
   cells.sort((a, b) => b.distance - a.distance);
-  return serialize(cells[0].cell);
+  const fallback = cells[0].cell;
+  return cacheResult(fallback, serialize(fallback), resolution);
 }
 
 // The IJToS function uses the triangular lattice which only approximates the pentagon lattice

--- a/modules/traversal/global-neighbors.ts
+++ b/modules/traversal/global-neighbors.ts
@@ -2,83 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) A5 contributors
 
-import type { Orientation, Triple } from '../lattice';
-import { sToAnchor, anchorToTriple, tripleToAnchor, tripleToS, tripleParity, tripleInBounds } from '../lattice';
+import { sToAnchor, anchorToTriple, tripleToAnchor, tripleParity } from '../lattice';
 import type { Origin } from '../core/utils';
 import { deserialize, serialize, FIRST_HILBERT_RESOLUTION } from '../core/serialization';
 import { segmentToQuintant, quintantToSegment, origins } from '../core/origin';
 import { FACE_ADJACENCY } from '../core/face-adjacency';
 import { compareBigint } from '../utils/bigint';
 import { findQuintantNeighborS } from './quintant-neighbors';
-
-/** Neighbor delta: [dx, dy, dz, isEdgeSharing] */
-type NeighborDelta = [number, number, number, boolean];
-
-/** Shared state for neighbor search helpers. */
-interface NeighborContext {
-  hilbertRes: number;
-  resolution: number;
-  maxS: bigint;
-  maxRow: number;
-  edgeOnly: boolean;
-  neighborSet: Set<bigint>;
-}
-
-/**
- * Cross-quintant left-edge deltas (source z=0), indexed by `parity * 2 + (yOdd ? 1 : 0)`.
- * Applied to the swapped base triple [0, y, x] in the previous quintant.
- */
-const LEFT_EDGE_DELTAS: NeighborDelta[][] = [
-  /* parity=0, yEven */ [[0, 0, 0, true], [0, 0, 1, false]],
-  /* parity=0, yOdd  */ [[0, 0, 0, true], [0, 1, 0, true], [0, -1, 1, false], [0, 1, -1, false]],
-  /* parity=1, yEven */ [],
-  /* parity=1, yOdd  */ [[0, -1, 0, true], [0, 0, -1, false]],
-];
-
-/**
- * Cross-quintant right-edge deltas (source x=0), indexed by `parity * 2 + (yOdd ? 1 : 0)`.
- * Applied to the swapped base triple [z, y, 0] in the next quintant.
- */
-const RIGHT_EDGE_DELTAS: NeighborDelta[][] = [
-  /* parity=0, yEven */ [[0, 0, 0, true], [0, 1, 0, true], [-1, 1, 0, false], [1, -1, 0, false]],
-  /* parity=0, yOdd  */ [[0, 0, 0, true], [1, 0, 0, false]],
-  /* parity=1, yEven */ [[0, -1, 0, true], [-1, 0, 0, false]],
-  /* parity=1, yOdd  */ [],
-];
-
-/**
- * Cross-face base-edge deltas (source y=maxRow), indexed by parity.
- * Applied to the mirrored position [z, maxRow, x] on the adjacent face.
- */
-const CROSS_FACE_DELTAS: NeighborDelta[][] = [
-  /* parity=0 */ [[0, 0, 0, true], [1, 0, 0, true], [1, 0, -1, false]],
-  /* parity=1 */ [[0, 0, -1, true], [0, 0, 0, false]],
-];
-
-/** Try to convert a triple to a cell ID and add it to the neighbor set. */
-function addNeighbor(
-  ctx: NeighborContext,
-  neighborTriple: Triple, orientation: Orientation,
-  neighborOrigin: Origin, neighborSegment: number
-): void {
-  const s = tripleToS(neighborTriple, ctx.hilbertRes, orientation);
-  if (s === null || s < 0n || s >= ctx.maxS) return;
-  ctx.neighborSet.add(serialize({origin: neighborOrigin, segment: neighborSegment, S: s, resolution: ctx.resolution}));
-}
-
-/** Apply a delta table to a base triple and add valid neighbors. */
-function addDeltaNeighbors(
-  ctx: NeighborContext,
-  base: Triple, deltas: NeighborDelta[],
-  orientation: Orientation, neighborOrigin: Origin, neighborSegment: number
-): void {
-  for (const [dx, dy, dz, isEdge] of deltas) {
-    if (ctx.edgeOnly && !isEdge) continue;
-    const neighborTriple: Triple = {x: base.x + dx, y: base.y + dy, z: base.z + dz};
-    if (!tripleInBounds(neighborTriple, ctx.maxRow)) continue;
-    addNeighbor(ctx, neighborTriple, orientation, neighborOrigin, neighborSegment);
-  }
-}
+import { getBoundaryNeighbors } from './lattice-boundary';
 
 /** Serialize a res 1 cell from origin and quintant. */
 function serializeRes1(origin: Origin, quintant: number): bigint {
@@ -143,25 +74,13 @@ function getRes1Neighbors(origin: Origin, segment: number, edgeOnly: boolean): b
 /**
  * Get all neighbors of a cell across quintant and face boundaries.
  *
- * Uses three strategies:
+ * Within-quintant candidates are validated with `isNeighbor()` in uv space
+ * (via `findQuintantNeighborS`). Cross-quintant, cross-face, apex, and
+ * corner neighbors are emitted by the shared `forEachBoundaryNeighbor`
+ * helper using fixed delta tables — see `lattice-boundary.ts`.
  *
- * **Within-quintant**: Standard triple coordinate approach — generate ±1 candidate
- * triples, validate with isNeighbor in uv space, convert to cell IDs.
- *
- * **Cross-quintant**: Transform the source cell's IJ center into each adjacent
- * quintant's coordinate system, compute the "virtual" triple coordinates there,
- * then generate ±1 neighbor triples from that virtual position. Also transforms
- * out-of-bounds candidate triples through face-space to find their target quintant.
- * Both validated with isNeighbor() in uv space.
- *
- * **Cross-face**: For cells at the base edge (y=maxRow), maps to the adjacent
- * dodecahedron face using the x↔z swap rule. Validated by mirroring candidates
- * back to the source face and checking isNeighbor() in uv space.
- *
- * @param cellId - Full cell ID (bigint)
  * @param options.edgeOnly - If true, return only edge-sharing neighbors (5 per cell).
  *   Default false returns all neighbors including vertex-only neighbors (6-8 per cell).
- * @returns Array of neighbor cell IDs (bigint)
  */
 export function getGlobalCellNeighbors(cellId: bigint, options?: {edgeOnly?: boolean}): bigint[] {
   const {origin, segment, S, resolution} = deserialize(cellId);
@@ -179,98 +98,25 @@ export function getGlobalCellNeighbors(cellId: bigint, options?: {edgeOnly?: boo
   // Get uv anchor for isNeighbor validation (within-quintant)
   const uvSourceAnchor = tripleToAnchor(triple, hilbertRes, 'uv');
 
-  const ctx: NeighborContext = {
+  const neighborSet = new Set<bigint>();
+
+  // --- Within-quintant: validated by isNeighbor() in uv space ---
+  for (const neighborS of findQuintantNeighborS(triple, uvSourceAnchor, S, hilbertRes, sourceOrientation, edgeOnly)) {
+    neighborSet.add(serialize({origin, segment, S: neighborS, resolution}));
+  }
+
+  // --- Cross-quintant / cross-face / apex / corner: shared lattice-boundary helper ---
+  const boundaryNeighbors = getBoundaryNeighbors({
+    triple,
+    parity: tripleParity(triple),
+    sourceQuintant,
+    origin,
     hilbertRes,
-    resolution,
     maxS: 4n ** BigInt(hilbertRes),
     maxRow: (1 << hilbertRes) - 1,
-    edgeOnly,
-    neighborSet: new Set<bigint>(),
-  };
+    resolution,
+  }, edgeOnly);
+  for (const cellId of boundaryNeighbors) neighborSet.add(cellId);
 
-  // --- Within-quintant neighbors ---
-  for (const neighborS of findQuintantNeighborS(triple, uvSourceAnchor, S, hilbertRes, sourceOrientation, ctx.edgeOnly)) {
-    ctx.neighborSet.add(serialize({origin, segment, S: neighborS, resolution}));
-  }
-
-  // --- Cross-quintant neighbors ---
-  //
-  // Adjacent quintants share a lateral edge. The left column of one quintant
-  // (z=0) aligns with the right column of the next quintant (x=0) via a 180°
-  // rotation. The triple coordinate mapping across lateral edges swaps x and z,
-  // exactly like cross-face base edges.
-  const parity = tripleParity(triple); // 0 or 1
-  const yOdd = triple.y % 2 !== 0;
-  const deltaIndex = parity * 2 + (yOdd ? 1 : 0);
-
-  // Left edge (z=0): neighbor in previous quintant at swapped [0, y, x]
-  if (triple.z === 0) {
-    const targetQuintant = (sourceQuintant - 1 + 5) % 5;
-    const {segment: targetSegment, orientation: targetOrientation} = quintantToSegment(targetQuintant, origin);
-    const swappedBase: Triple = {x: 0, y: triple.y, z: triple.x};
-    addDeltaNeighbors(ctx, swappedBase, LEFT_EDGE_DELTAS[deltaIndex], targetOrientation, origin, targetSegment);
-  }
-
-  // Right edge (x=0): neighbor in next quintant at swapped [z, y, 0]
-  if (triple.x === 0) {
-    const targetQuintant = (sourceQuintant + 1) % 5;
-    const {segment: targetSegment, orientation: targetOrientation} = quintantToSegment(targetQuintant, origin);
-    const swappedBase: Triple = {x: triple.z, y: triple.y, z: 0};
-    addDeltaNeighbors(ctx, swappedBase, RIGHT_EDGE_DELTAS[deltaIndex], targetOrientation, origin, targetSegment);
-  }
-
-  // --- Cross-face neighbors ---
-  // For cells at the base edge (y = maxRow), neighbors may lie on an adjacent
-  // dodecahedron face. The base edge of each quintant is shared with a specific
-  // quintant on an adjacent face. The triple coordinate mapping across the shared
-  // edge swaps x and z: source [x, maxRow, z] ↔ target [z, maxRow, x].
-  if (triple.y === ctx.maxRow) {
-    const [adjFaceId, adjQuintant] = FACE_ADJACENCY[origin.id][sourceQuintant];
-    const adjOrigin = origins[adjFaceId];
-    const {segment: adjSegment, orientation: adjOrientation} = quintantToSegment(adjQuintant, adjOrigin);
-    const mirroredBase: Triple = {x: triple.z, y: ctx.maxRow, z: triple.x};
-    addDeltaNeighbors(ctx, mirroredBase, CROSS_FACE_DELTAS[parity], adjOrientation, adjOrigin, adjSegment);
-  }
-
-  // Apex: [0,0,0] cells from all 5 quintants meet at the face center
-  if (triple.x === 0 && triple.y === 0 && triple.z === 0) {
-    for (let q = 0; q < 5; q++) {
-      if (q === sourceQuintant) continue;
-      // Adjacent quintants (distance=1) share an edge; non-adjacent (distance=2) share only a vertex
-      const distance = Math.min(
-        (q - sourceQuintant + 5) % 5,
-        (sourceQuintant - q + 5) % 5
-      );
-      if (ctx.edgeOnly && distance !== 1) continue;
-      const {segment: targetSegment, orientation: targetOrientation} = quintantToSegment(q, origin);
-      addNeighbor(ctx, triple, targetOrientation, origin, targetSegment);
-    }
-  }
-
-  // Special case: base-left corner cells (triple [-maxRow, maxRow, 0]) sit at
-  // dodecahedron vertices where 3 faces meet. Each vertex has 3 [-maxRow,maxRow,0]
-  // cells (one from each face) that are mutual edge-sharing neighbors.
-  //
-  // The symmetric base-right corner [0, maxRow, -maxRow] does NOT need special
-  // handling: its cross-quintant right-edge path lands on [-maxRow, maxRow, 0] in
-  // Q+1 (same face), and its cross-face path lands on [-maxRow, maxRow, 0] on the
-  // adjacent face — both of which are left corners that fully cover the vertex.
-  if (triple.x === -ctx.maxRow && triple.y === ctx.maxRow && triple.z === 0) {
-    // Corner cells are always edge-sharing neighbors (distance 0)
-    // Vertex neighbor 1: across the previous quintant's base edge
-    const prevQuintant = (sourceQuintant - 1 + 5) % 5;
-    const [prevAdjFaceId, prevAdjQuintant] = FACE_ADJACENCY[origin.id][prevQuintant];
-    const prevAdjOrigin = origins[prevAdjFaceId];
-    const {segment: prevAdjSegment, orientation: prevAdjOrientation} = quintantToSegment(prevAdjQuintant, prevAdjOrigin);
-    addNeighbor(ctx, triple, prevAdjOrientation, prevAdjOrigin, prevAdjSegment);
-
-    // Vertex neighbor 2: adjacent quintant on the primary cross-face
-    const [crossFaceId, crossQuintant] = FACE_ADJACENCY[origin.id][sourceQuintant];
-    const crossOrigin = origins[crossFaceId];
-    const nextCrossQuintant = (crossQuintant + 1) % 5;
-    const {segment: crossSegment, orientation: crossOrientation} = quintantToSegment(nextCrossQuintant, crossOrigin);
-    addNeighbor(ctx, triple, crossOrientation, crossOrigin, crossSegment);
-  }
-
-  return Array.from(ctx.neighborSet).sort(compareBigint);
+  return Array.from(neighborSet).sort(compareBigint);
 }

--- a/modules/traversal/lattice-boundary.ts
+++ b/modules/traversal/lattice-boundary.ts
@@ -1,0 +1,159 @@
+// A5
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) A5 contributors
+
+import type { Orientation, Triple } from '../lattice';
+import { tripleToS, tripleInBounds } from '../lattice';
+import type { Origin } from '../core/utils';
+import { serialize } from '../core/serialization';
+import { quintantToSegment, origins } from '../core/origin';
+import { FACE_ADJACENCY } from '../core/face-adjacency';
+
+/** Neighbor delta: [dx, dy, dz, isEdgeSharing] */
+export type NeighborDelta = [number, number, number, boolean];
+
+/**
+ * Cross-quintant left-edge deltas (source z=0), indexed by `parity * 2 + (yOdd ? 1 : 0)`.
+ * Applied to the swapped base triple [0, y, x] in the previous quintant.
+ */
+export const LEFT_EDGE_DELTAS: NeighborDelta[][] = [
+  /* parity=0, yEven */ [[0, 0, 0, true], [0, 0, 1, false]],
+  /* parity=0, yOdd  */ [[0, 0, 0, true], [0, 1, 0, true], [0, -1, 1, false], [0, 1, -1, false]],
+  /* parity=1, yEven */ [],
+  /* parity=1, yOdd  */ [[0, -1, 0, true], [0, 0, -1, false]],
+];
+
+/**
+ * Cross-quintant right-edge deltas (source x=0), indexed by `parity * 2 + (yOdd ? 1 : 0)`.
+ * Applied to the swapped base triple [z, y, 0] in the next quintant.
+ */
+export const RIGHT_EDGE_DELTAS: NeighborDelta[][] = [
+  /* parity=0, yEven */ [[0, 0, 0, true], [0, 1, 0, true], [-1, 1, 0, false], [1, -1, 0, false]],
+  /* parity=0, yOdd  */ [[0, 0, 0, true], [1, 0, 0, false]],
+  /* parity=1, yEven */ [[0, -1, 0, true], [-1, 0, 0, false]],
+  /* parity=1, yOdd  */ [],
+];
+
+/**
+ * Cross-face base-edge deltas (source y=maxRow), indexed by parity.
+ * Applied to the mirrored position [z, maxRow, x] on the adjacent face.
+ */
+export const CROSS_FACE_DELTAS: NeighborDelta[][] = [
+  /* parity=0 */ [[0, 0, 0, true], [1, 0, 0, true], [1, 0, -1, false]],
+  /* parity=1 */ [[0, 0, -1, true], [0, 0, 0, false]],
+];
+
+/** Source-cell context shared by all boundary-neighbor cases. */
+export interface BoundaryContext {
+  triple: Triple;
+  parity: number;
+  sourceQuintant: number;
+  origin: Origin;
+  hilbertRes: number;
+  maxS: bigint;
+  maxRow: number;
+  resolution: number;
+}
+
+/** If the triple maps to a valid cell, append its cell ID to `out`. */
+function pushTriple(
+  out: bigint[], triple: Triple, orientation: Orientation,
+  origin: Origin, segment: number, ctx: BoundaryContext,
+): void {
+  if (!tripleInBounds(triple, ctx.maxRow)) return;
+  const s = tripleToS(triple, ctx.hilbertRes, orientation);
+  if (s === null || s < 0n || s >= ctx.maxS) return;
+  out.push(serialize({origin, segment, S: s, resolution: ctx.resolution}));
+}
+
+/** Apply a delta table to a base triple, appending each valid cell. */
+function pushDeltas(
+  out: bigint[], base: Triple, deltas: NeighborDelta[], edgeOnly: boolean,
+  orientation: Orientation, origin: Origin, segment: number, ctx: BoundaryContext,
+): void {
+  for (const [dx, dy, dz, isEdge] of deltas) {
+    if (edgeOnly && !isEdge) continue;
+    pushTriple(out, {x: base.x + dx, y: base.y + dy, z: base.z + dz}, orientation, origin, segment, ctx);
+  }
+}
+
+/**
+ * Return every neighbor that lies outside the source cell's quintant: cross-quintant
+ * lateral edges, cross-face base edge, apex (face center), and the [-maxRow, maxRow, 0]
+ * vertex corner. The within-quintant ±1 candidates are NOT covered here — callers
+ * generate those directly.
+ *
+ * The result may contain duplicates and the order is not stable; callers
+ * deduplicate (via Set) or accept duplicates if their downstream pipeline tolerates them.
+ *
+ * @param ctx         source-cell context
+ * @param edgeOnly    drop vertex-only neighbors
+ * @param skipCorners skip the `[-maxRow, maxRow, 0]` corner case (only `getEdgeLatticeNeighbors` does)
+ */
+export function getBoundaryNeighbors(
+  ctx: BoundaryContext,
+  edgeOnly: boolean,
+  skipCorners = false,
+): bigint[] {
+  const out: bigint[] = [];
+  const {triple, parity, sourceQuintant, origin, maxRow} = ctx;
+  const yOdd = triple.y % 2 !== 0;
+  const deltaIndex = parity * 2 + (yOdd ? 1 : 0);
+
+  // Left edge (z=0): neighbor in previous quintant at swapped [0, y, x]
+  if (triple.z === 0) {
+    const targetQuintant = (sourceQuintant - 1 + 5) % 5;
+    const {segment, orientation} = quintantToSegment(targetQuintant, origin);
+    pushDeltas(out, {x: 0, y: triple.y, z: triple.x}, LEFT_EDGE_DELTAS[deltaIndex], edgeOnly,
+      orientation, origin, segment, ctx);
+  }
+
+  // Right edge (x=0): neighbor in next quintant at swapped [z, y, 0]
+  if (triple.x === 0) {
+    const targetQuintant = (sourceQuintant + 1) % 5;
+    const {segment, orientation} = quintantToSegment(targetQuintant, origin);
+    pushDeltas(out, {x: triple.z, y: triple.y, z: 0}, RIGHT_EDGE_DELTAS[deltaIndex], edgeOnly,
+      orientation, origin, segment, ctx);
+  }
+
+  // Base edge (y=maxRow): neighbor on adjacent face at mirrored [z, maxRow, x]
+  if (triple.y === maxRow) {
+    const [adjFaceId, adjQuintant] = FACE_ADJACENCY[origin.id][sourceQuintant];
+    const adjOrigin = origins[adjFaceId];
+    const {segment, orientation} = quintantToSegment(adjQuintant, adjOrigin);
+    pushDeltas(out, {x: triple.z, y: maxRow, z: triple.x}, CROSS_FACE_DELTAS[parity], edgeOnly,
+      orientation, adjOrigin, segment, ctx);
+  }
+
+  // Apex [0,0,0]: cells from all 5 quintants meet at the face center
+  if (triple.x === 0 && triple.y === 0 && triple.z === 0) {
+    for (let q = 0; q < 5; q++) {
+      if (q === sourceQuintant) continue;
+      const distance = Math.min((q - sourceQuintant + 5) % 5, (sourceQuintant - q + 5) % 5);
+      if (edgeOnly && distance !== 1) continue;
+      const {segment, orientation} = quintantToSegment(q, origin);
+      pushTriple(out, triple, orientation, origin, segment, ctx);
+    }
+  }
+
+  // Base-left corner [-maxRow, maxRow, 0]: 3 dodecahedron faces meet at this vertex.
+  // The symmetric base-right corner is implicitly covered: its cross-quintant and
+  // cross-face paths land on the [-maxRow, maxRow, 0] cell of neighboring quintants.
+  if (!skipCorners && triple.x === -maxRow && triple.y === maxRow && triple.z === 0) {
+    // Vertex neighbor 1: across the previous quintant's base edge
+    const prevQuintant = (sourceQuintant - 1 + 5) % 5;
+    const [prevAdjFaceId, prevAdjQuintant] = FACE_ADJACENCY[origin.id][prevQuintant];
+    const prevAdjOrigin = origins[prevAdjFaceId];
+    const {segment: prevAdjSegment, orientation: prevAdjOrientation} = quintantToSegment(prevAdjQuintant, prevAdjOrigin);
+    pushTriple(out, triple, prevAdjOrientation, prevAdjOrigin, prevAdjSegment, ctx);
+
+    // Vertex neighbor 2: adjacent quintant on the primary cross-face
+    const [crossFaceId, crossQuintant] = FACE_ADJACENCY[origin.id][sourceQuintant];
+    const crossOrigin = origins[crossFaceId];
+    const nextCrossQuintant = (crossQuintant + 1) % 5;
+    const {segment: crossSegment, orientation: crossOrientation} = quintantToSegment(nextCrossQuintant, crossOrigin);
+    pushTriple(out, triple, crossOrientation, crossOrigin, crossSegment, ctx);
+  }
+
+  return out;
+}


### PR DESCRIPTION
#### Change List
- Cache cell projection in `cell.ts` to avoid repeated calls
- Refactor `global-neighbors.ts` to share boundary logic via new `lattice-boundary.ts` file