### PR TITLE
feat: Add cellEdgeLengthAvg function

### DIFF
--- a/docs/api-reference/cell-info.md
+++ b/docs/api-reference/cell-info.md
@@ -53,3 +53,30 @@ import { cellArea } from 'a5-js';
 
 console.log(cellArea(20)); // ~30 m²
 ```
+
+### cellEdgeLengthAvg
+
+Returns the average edge length of a cell at a given resolution in meters. Individual
+edge lengths vary from the average by roughly ±10%, depending on the cell's
+shape and its position on the globe.
+
+```ts
+function cellEdgeLengthAvg(resolution: number): number;
+```
+
+#### Parameters
+
+- `resolution` **(number)** The resolution level
+
+#### Return value
+
+- **(number)** Average edge length of a cell in meters
+
+#### Example
+
+```ts
+import { cellEdgeLengthAvg } from 'a5-js';
+
+console.log(cellEdgeLengthAvg(2)); // ~1,190,000 m
+console.log(cellEdgeLengthAvg(10)); // ~4,680 m
+```

--- a/modules/core/cell-info.ts
+++ b/modules/core/cell-info.ts
@@ -48,3 +48,25 @@ export function cellArea(resolution: number): number {
   if (resolution < 0) return AUTHALIC_AREA_EARTH;
   return AUTHALIC_AREA_EARTH / getNumCells(resolution);
 }
+
+// Mean cell edge length divided by sqrt(cellArea), measured exhaustively from the
+// cell boundaries. Resolution 0 cells (dodecahedron faces) and resolution 1 cells
+// (triangular quintants) have their own geometry; from resolution 2 the pentagonal
+// tiling refines self-similarly and the ratio converges to ~0.8211, so a constant
+// serves all higher resolutions.
+const EDGE_LENGTH_RATIOS = [0.7131, 1.4818, 0.8164, 0.8198, 0.8208, 0.821];
+const EDGE_LENGTH_RATIO = 0.8211;
+
+/**
+ * Returns the average edge length of a cell at a given resolution in meters.
+ * Individual edge lengths vary from the average by roughly ±10%, depending
+ * on the cell's shape and its position on the globe.
+ *
+ * @param resolution The resolution level
+ * @returns Average edge length of a cell in meters
+ */
+export function cellEdgeLengthAvg(resolution: number): number {
+  if (resolution < 0) resolution = 0;
+  const ratio = EDGE_LENGTH_RATIOS[resolution] ?? EDGE_LENGTH_RATIO;
+  return ratio * Math.sqrt(cellArea(resolution));
+}

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -21,7 +21,7 @@ export {
   MAX_RESOLUTION,
   WORLD_CELL
 } from './core/serialization';
-export {getNumCells, getNumChildren, cellArea} from './core/cell-info';
+export {getNumCells, getNumChildren, cellArea, cellEdgeLengthAvg} from './core/cell-info';
 export {compact, uncompact} from './core/compact';
 
 // Traversal

--- a/scripts/fixtures/core/cell-info.cjs
+++ b/scripts/fixtures/core/cell-info.cjs
@@ -1,18 +1,20 @@
 const fs = require('fs');
 const path = require('path');
 
-const {getNumCells, getNumChildren, cellArea} = require('../../a5-test.cjs');
+const {getNumCells, getNumChildren, cellArea, cellEdgeLengthAvg} = require('../../a5-test.cjs');
 
 // Generate data for resolutions 0 to 30
-const cellInfoData = {numCells: [], numChildren: [], cellArea: []};
+const cellInfoData = {numCells: [], numChildren: [], cellArea: [], cellEdgeLengthAvg: []};
 
 for (let resolution = 0; resolution <= 30; resolution++) {
   const count = getNumCells(resolution);
   const countBigInt = getNumCells(BigInt(resolution));
   const areaM2 = cellArea(resolution);
+  const lengthM = cellEdgeLengthAvg(resolution);
 
   cellInfoData.numCells.push({resolution, count, countBigInt: countBigInt.toString()});
   cellInfoData.cellArea.push({resolution, areaM2});
+  cellInfoData.cellEdgeLengthAvg.push({resolution, lengthM});
 }
 
 // Generate numChildren pairs

--- a/tests/cell-info.test.ts
+++ b/tests/cell-info.test.ts
@@ -1,6 +1,10 @@
 import {describe, expect, test} from 'vitest';
-import {getNumCells, getNumChildren, cellArea} from 'a5/core/cell-info';
+import {getNumCells, getNumChildren, cellArea, cellEdgeLengthAvg} from 'a5/core/cell-info';
+import {cellToBoundary, getResolution} from 'a5';
+import {hexToU64} from 'a5/core/hex';
+import {AUTHALIC_RADIUS_EARTH} from 'a5/core/constants';
 import cellInfoFixtures from './fixtures/cell-info.json';
+import serializationFixtures from './fixtures/serialization.json';
 
 describe('getNumCells', () => {
   test('returns correct number of cells for all resolutions', () => {
@@ -24,5 +28,44 @@ describe('cellArea', () => {
     cellInfoFixtures.cellArea.forEach(fixture => {
       expect(cellArea(fixture.resolution)).toBe(fixture.areaM2);
     });
+  });
+});
+
+describe('cellEdgeLengthAvg', () => {
+  test('returns correct edge length for all resolutions', () => {
+    cellInfoFixtures.cellEdgeLengthAvg.forEach(fixture => {
+      expect(cellEdgeLengthAvg(fixture.resolution)).toBe(fixture.lengthM);
+    });
+  });
+
+  test('every boundary edge of the test cells is within ±10% of the average', () => {
+    const DEG = Math.PI / 180;
+    const geodesic = (a: number[], b: number[]) => {
+      const [lat1, lat2] = [a[1] * DEG, b[1] * DEG];
+      const h =
+        Math.sin((lat2 - lat1) / 2) ** 2 +
+        Math.cos(lat1) * Math.cos(lat2) * Math.sin(((b[0] - a[0]) * DEG) / 2) ** 2;
+      return 2 * AUTHALIC_RADIUS_EARTH * Math.asin(Math.sqrt(h));
+    };
+
+    // Sample each edge with multiple segments to measure its true curved length
+    const SEGMENTS = 10;
+    for (const hex of serializationFixtures.testIds) {
+      const cell = hexToU64(hex);
+      const resolution = getResolution(cell);
+      const avg = cellEdgeLengthAvg(resolution);
+      const boundary = cellToBoundary(cell, {closedRing: true, segments: SEGMENTS});
+      const numEdges = (boundary.length - 1) / SEGMENTS;
+      for (let e = 0; e < numEdges; e++) {
+        let length = 0;
+        for (let i = 0; i < SEGMENTS; i++) {
+          const idx = e * SEGMENTS + i;
+          length += geodesic(boundary[idx], boundary[idx + 1]);
+        }
+        const ratio = length / avg;
+        expect(ratio, `cell ${hex} edge ${e}`).toBeGreaterThan(0.9);
+        expect(ratio, `cell ${hex} edge ${e}`).toBeLessThan(1.1);
+      }
+    }
   });
 });

--- a/tests/cell-info.test.ts
+++ b/tests/cell-info.test.ts
@@ -43,8 +43,7 @@ describe('cellEdgeLengthAvg', () => {
     const geodesic = (a: number[], b: number[]) => {
       const [lat1, lat2] = [a[1] * DEG, b[1] * DEG];
       const h =
-        Math.sin((lat2 - lat1) / 2) ** 2 +
-        Math.cos(lat1) * Math.cos(lat2) * Math.sin(((b[0] - a[0]) * DEG) / 2) ** 2;
+        Math.sin((lat2 - lat1) / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(((b[0] - a[0]) * DEG) / 2) ** 2;
       return 2 * AUTHALIC_RADIUS_EARTH * Math.asin(Math.sqrt(h));
     };
 

--- a/tests/fixtures/cell-info.json
+++ b/tests/fixtures/cell-info.json
@@ -613,5 +613,131 @@
       "resolution": 30,
       "areaM2": 0.000029494093786455682
     }
+  ],
+  "cellEdgeLengthAvg": [
+    {
+      "resolution": 0,
+      "lengthM": 4649142.322893622
+    },
+    {
+      "resolution": 1,
+      "lengthM": 4320430.199988446
+    },
+    {
+      "resolution": 2,
+      "lengthM": 1190173.8477765447
+    },
+    {
+      "resolution": 3,
+      "lengthM": 597565.2378780079
+    },
+    {
+      "resolution": 4,
+      "lengthM": 299147.07687867095
+    },
+    {
+      "resolution": 5,
+      "lengthM": 149609.98423330215
+    },
+    {
+      "resolution": 6,
+      "lengthM": 74814.10356514277
+    },
+    {
+      "resolution": 7,
+      "lengthM": 37407.05178257138
+    },
+    {
+      "resolution": 8,
+      "lengthM": 18703.52589128569
+    },
+    {
+      "resolution": 9,
+      "lengthM": 9351.762945642846
+    },
+    {
+      "resolution": 10,
+      "lengthM": 4675.881472821423
+    },
+    {
+      "resolution": 11,
+      "lengthM": 2337.9407364107115
+    },
+    {
+      "resolution": 12,
+      "lengthM": 1168.9703682053557
+    },
+    {
+      "resolution": 13,
+      "lengthM": 584.4851841026779
+    },
+    {
+      "resolution": 14,
+      "lengthM": 292.24259205133893
+    },
+    {
+      "resolution": 15,
+      "lengthM": 146.12129602566947
+    },
+    {
+      "resolution": 16,
+      "lengthM": 73.06064801283473
+    },
+    {
+      "resolution": 17,
+      "lengthM": 36.530324006417366
+    },
+    {
+      "resolution": 18,
+      "lengthM": 18.265162003208683
+    },
+    {
+      "resolution": 19,
+      "lengthM": 9.132581001604342
+    },
+    {
+      "resolution": 20,
+      "lengthM": 4.566290500802171
+    },
+    {
+      "resolution": 21,
+      "lengthM": 2.2831452504010854
+    },
+    {
+      "resolution": 22,
+      "lengthM": 1.1415726252005427
+    },
+    {
+      "resolution": 23,
+      "lengthM": 0.5707863126002714
+    },
+    {
+      "resolution": 24,
+      "lengthM": 0.2853931563001357
+    },
+    {
+      "resolution": 25,
+      "lengthM": 0.14269657815006784
+    },
+    {
+      "resolution": 26,
+      "lengthM": 0.07134828907503392
+    },
+    {
+      "resolution": 27,
+      "lengthM": 0.03567414453751696
+    },
+    {
+      "resolution": 28,
+      "lengthM": 0.01783707226875848
+    },
+    {
+      "resolution": 29,
+      "lengthM": 0.00891853613437924
+    },
+    {
+      "resolution": 30,
+      "lengthM": 0.00445926806718962
+    }
   ]
 }


### PR DESCRIPTION
<!-- Short description of why change is needed -->
#### Background

While A5 already has a `cellArea` function, there is no trivial way to estimate the edge length of the cells. This PR adds a new function, `cellEdgeLengthAvg` which does exactly that

<!-- For all the PRs -->
#### Change List
- Add `cellEdgeLengthAvg` function
- Tests
- Docs
